### PR TITLE
switch to using ExternalProject for codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,20 @@ include(cmake/Platform.cmake)
 target_sources(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/entry.cpp)
 
 
-add_subdirectory(codegen)
+include(ExternalProject)
+
+set(GEODE_CODEGEN_BINARY_OUT ${CMAKE_CURRENT_BINARY_DIR}/codegen)
+ExternalProject_Add(CodegenProject
+	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/codegen
+	CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:STRING=${GEODE_CODEGEN_BINARY_OUT}"
+)
 
 add_custom_command(
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bindings/GeometryDash.bro
 			${CMAKE_CURRENT_SOURCE_DIR}/bindings/Cocos2d.bro
 			${CMAKE_CURRENT_SOURCE_DIR}/bindings/Entry.bro
-	COMMAND Codegen ${GEODE_TARGET_PLATFORM} bindings ${GEODE_CODEGEN_PATH}
+	DEPENDS CodegenProject
+	COMMAND ${GEODE_CODEGEN_BINARY_OUT}/Codegen ${GEODE_TARGET_PLATFORM} bindings ${GEODE_CODEGEN_PATH}
 	COMMAND echo codegen > ${GEODE_CODEGEN_PATH}/.stamp
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	COMMENT "Run Codegen"

--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -4,6 +4,8 @@ project(Codegen LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(Broma)
+add_subdirectory(../fmt ${CMAKE_CURRENT_BINARY_DIR}/fmt)
+add_subdirectory(../filesystem ${CMAKE_CURRENT_BINARY_DIR}/fs)
 
 file(GLOB SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
@@ -18,3 +20,5 @@ target_include_directories(Codegen PRIVATE
 target_precompile_headers(Codegen PRIVATE 
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Shared.hpp
 )
+
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
this is necessary in cross compilation enviroments, such as compiling for android or cross compiling to windows on linux, since we want the codegen executable to be of the current system, not the cross compilation target