### PR TITLE
Fix wrong usage of create_directory/create_directories API

### DIFF
--- a/loader/include/Geode/utils/file.hpp
+++ b/loader/include/Geode/utils/file.hpp
@@ -15,8 +15,8 @@ namespace geode::utils::file {
     GEODE_DLL Result<> writeString(ghc::filesystem::path const& path, std::string const& data);
     GEODE_DLL Result<> writeBinary(ghc::filesystem::path const& path, byte_array const& data);
 
-    GEODE_DLL Result<> createDirectory(ghc::filesystem::path const& path);
-    GEODE_DLL Result<> createDirectoryAll(ghc::filesystem::path const& path);
+    GEODE_DLL Result<bool> createDirectory(ghc::filesystem::path const& path);
+    GEODE_DLL Result<bool> createDirectoryAll(ghc::filesystem::path const& path);
     GEODE_DLL Result<std::vector<std::string>> listFiles(std::string const& path);
     GEODE_DLL Result<std::vector<std::string>> listFilesRecursively(std::string const& path);
 

--- a/loader/src/utils/file.cpp
+++ b/loader/src/utils/file.cpp
@@ -74,26 +74,22 @@ Result<> utils::file::writeBinary(ghc::filesystem::path const& path, byte_array 
     return Err("Unable to open file");
 }
 
-Result<> utils::file::createDirectory(ghc::filesystem::path const& path) {
+Result<bool> utils::file::createDirectory(ghc::filesystem::path const& path) {
     try {
-        if (ghc::filesystem::create_directory(path)) {
-            return Ok();
-        }
+        return Ok(ghc::filesystem::create_directory(path));
     }
     catch (...) {
+        return Err("Unable to create directory");
     }
-    return Err("Unable to create directory");
 }
 
-Result<> utils::file::createDirectoryAll(ghc::filesystem::path const& path) {
+Result<bool> utils::file::createDirectoryAll(ghc::filesystem::path const& path) {
     try {
-        if (ghc::filesystem::create_directories(path)) {
-            return Ok();
-        }
+        return Ok(ghc::filesystem::create_directories(path));
     }
     catch (...) {
+        return Err("Unable to create directories");
     }
-    return Err("Unable to create directories");
 }
 
 Result<std::vector<std::string>> utils::file::listFiles(std::string const& path) {


### PR DESCRIPTION
The returned bool indicates whether the directory was created or not, not whether it *failed* to create it (it might've already existed, which is not a fail, yet that'd still return false, because it didn't need to create the directory)