### PR TITLE
Added the supported metering variable to PlayLayer

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -4376,7 +4376,7 @@ class PlayLayer : GJBaseGameLayer, CCCircleWaveDelegate, CurrencyRewardDelegate,
     int unknown6b8;
     int unknown6bc;
     bool unk460;
-    bool unk461;
+    bool m_isAudioMeteringSupported;
     cocos2d::CCDictionary* unk464;
     gd::map<short, bool> unk468;
     bool m_collisionDisabled;


### PR DESCRIPTION
From my findings, legacy levels are indicated if this bool is false. If it is, GD will default to extracting the metering from the AudioEffectsLayer rather than using GameSoundManager.

I say this is likely a way of indicating a legacy mode because this can be found in all levels which were made before 2.1.