### PR TITLE
Add `geode::prelude` to replace `USE_GEODE_NAMESPACE()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here's a **Hello World** mod in Geode:
 #include <Geode/Bindings.hpp>
 #include <Geode/modify/MenuLayer.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class $modify(MenuLayer) {
 	void onMoreGames(CCObject*) {

--- a/loader/include/Geode/DefaultInclude.hpp
+++ b/loader/include/Geode/DefaultInclude.hpp
@@ -1,46 +1,9 @@
 #pragma once
 
+#include <Geode/Prelude.hpp>
 #include <Geode/c++stl/gdstdlib.hpp>
 #include <Geode/platform/platform.hpp>
 #include <variant>
-
-// Because C++ doesn't like using a
-// namespace that doesn't exist
-
-namespace geode {}
-
-namespace geode::addresser {}
-
-namespace geode::cast {}
-
-namespace geode::cocos {}
-
-namespace geode::utils {}
-
-namespace geode::helper {}
-
-namespace geode::op {}
-
-namespace geode::stream {}
-
-namespace geode::view {}
-
-namespace cocos2d {}
-
-namespace cocos2d::extension {}
-
-#define USE_GEODE_NAMESPACE()         \
-    using namespace geode;            \
-    using namespace geode::addresser; \
-    using namespace geode::cast;      \
-    using namespace geode::cocos;     \
-    using namespace geode::helper;    \
-    using namespace geode::utils;     \
-    using namespace geode::op;        \
-    using namespace geode::stream;    \
-    using namespace geode::view;      \
-    using namespace cocos2d;          \
-    using namespace cocos2d::extension;
 
 #define GEODE_STATIC_PTR(type, name)          \
     static type* s_##name;                    \

--- a/loader/include/Geode/Prelude.hpp
+++ b/loader/include/Geode/Prelude.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+// Because C++ doesn't like using
+// namespaces that don't exist
+namespace geode {
+    namespace addresser {}
+    namespace cast {}
+    namespace cocos {}
+    namespace utils {}
+    namespace helper {}
+    namespace op {}
+    namespace stream {}
+    namespace view {}
+}
+
+namespace cocos2d {
+    namespace extension {}
+}
+
+namespace geode {
+    namespace prelude {
+        using namespace ::geode;
+        using namespace ::geode::addresser;
+        using namespace ::geode::cast;
+        using namespace ::geode::cocos;
+        using namespace ::geode::helper;
+        using namespace ::geode::utils;
+        using namespace ::geode::op;
+        using namespace ::geode::stream;
+        using namespace ::geode::view;
+        using namespace ::cocos2d;
+        using namespace ::cocos2d::extension;
+    }
+
+    namespace [[deprecated("Use `using namespace geode::prelude` instead!")]] old_prelude {
+        using namespace ::geode::prelude;
+    }
+}
+
+#define USE_GEODE_NAMESPACE() using namespace geode::old_prelude;

--- a/loader/src/cocos2d-ext/CCFileUtils.cpp
+++ b/loader/src/cocos2d-ext/CCFileUtils.cpp
@@ -3,7 +3,7 @@
 #include <Geode/utils/ranges.hpp>
 #include <cocos2d.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 static std::vector<CCTexturePack> PACKS;
 static std::vector<std::string> PATHS;

--- a/loader/src/cocos2d-ext/Layout.cpp
+++ b/loader/src/cocos2d-ext/Layout.cpp
@@ -5,7 +5,7 @@
 #include <Geode/binding/CCMenuItemSpriteExtra.hpp>
 #include <Geode/binding/CCMenuItemToggler.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #pragma warning(disable: 4273)
 

--- a/loader/src/hooks/DynamicCastFix.cpp
+++ b/loader/src/hooks/DynamicCastFix.cpp
@@ -2,7 +2,7 @@
 
 #ifdef GEODE_IS_MACOS
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
     #include <Geode/loader/Mod.hpp>
     #include <Geode/modify/Modify.hpp>

--- a/loader/src/hooks/GeodeNodeMetadata.cpp
+++ b/loader/src/hooks/GeodeNodeMetadata.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/CCNode.hpp>
 #include <cocos2d.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 using namespace geode::modifier;
 
 #pragma warning(push)

--- a/loader/src/hooks/LoadingLayer.cpp
+++ b/loader/src/hooks/LoadingLayer.cpp
@@ -5,7 +5,7 @@
 #include <fmt/format.h>
 #include <loader/LoaderImpl.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 struct CustomLoadingLayer : Modify<CustomLoadingLayer, LoadingLayer> {
     bool m_updatingResources;

--- a/loader/src/hooks/MenuLayer.cpp
+++ b/loader/src/hooks/MenuLayer.cpp
@@ -14,7 +14,7 @@
 #include <loader/ModImpl.hpp>
 #include <loader/LoaderImpl.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #pragma warning(disable : 4217)
 

--- a/loader/src/hooks/MessageBoxFix.cpp
+++ b/loader/src/hooks/MessageBoxFix.cpp
@@ -6,7 +6,7 @@
     #include <Geode/loader/Mod.hpp>
     #include <Geode/modify/Modify.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 // for some reason RobTop uses MessageBoxW in his GLFW error handler.
 // no one knows how this is possible (he passes char* to wchar_t*).

--- a/loader/src/hooks/TouchDispatcherFix.cpp
+++ b/loader/src/hooks/TouchDispatcherFix.cpp
@@ -1,4 +1,4 @@
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #include <Geode/modify/CCTouchDispatcher.hpp>
 

--- a/loader/src/hooks/persist.cpp
+++ b/loader/src/hooks/persist.cpp
@@ -1,6 +1,6 @@
 #include <Geode/ui/SceneManager.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #include <Geode/modify/AchievementNotifier.hpp>
 

--- a/loader/src/hooks/save.cpp
+++ b/loader/src/hooks/save.cpp
@@ -1,6 +1,6 @@
 #include <Geode/loader/Loader.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #include <Geode/modify/AppDelegate.hpp>
 

--- a/loader/src/hooks/update.cpp
+++ b/loader/src/hooks/update.cpp
@@ -1,6 +1,6 @@
 #include <loader/LoaderImpl.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #include <Geode/modify/CCScheduler.hpp>
 

--- a/loader/src/hooks/updateResources.cpp
+++ b/loader/src/hooks/updateResources.cpp
@@ -2,7 +2,7 @@
 #include <Geode/modify/LoadingLayer.hpp>
 #include <Geode/modify/GameManager.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 struct ResourcesUpdate : Modify<ResourcesUpdate, LoadingLayer> {
     void loadAssets() {

--- a/loader/src/ids/AddIDs.hpp
+++ b/loader/src/ids/AddIDs.hpp
@@ -3,13 +3,13 @@
 #include <Geode/Bindings.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 static constexpr int32_t GEODE_ID_PRIORITY = 0x100000;
 
-template<class T = CCNode>
+template <class T = CCNode>
     requires std::is_base_of_v<CCNode, T>
-T* setIDSafe(CCNode* node, int index, const char* id) {
+T* setIDSafe(CCNode* node, int index, char const* id) {
     if constexpr (std::is_same_v<CCNode, T>) {
         if (auto child = getChild(node, index)) {
             child->setID(id);
@@ -56,8 +56,10 @@ static void switchChildrenToMenu(CCNode* parent, CCMenu* menu, Args... args) {
     }
 }
 
-template <typename T, typename ...Args>
-static CCMenu* detachAndCreateMenu(CCNode* parent, const char* menuID, Layout* layout, T first, Args... args) {
+template <typename T, typename... Args>
+static CCMenu* detachAndCreateMenu(
+    CCNode* parent, char const* menuID, Layout* layout, T first, Args... args
+) {
     if (!first) {
         auto menu = CCMenu::create();
         menu->setID(menuID);

--- a/loader/src/ids/CreatorLayer.cpp
+++ b/loader/src/ids/CreatorLayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/CreatorLayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 template<class... Args>
 static void reorderButtons(Args... args) {

--- a/loader/src/ids/EditLevelLayer.cpp
+++ b/loader/src/ids/EditLevelLayer.cpp
@@ -5,7 +5,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <Geode/ui/BasedButtonSprite.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(EditLevelLayer) {
     setIDs(

--- a/loader/src/ids/EditorPauseLayer.cpp
+++ b/loader/src/ids/EditorPauseLayer.cpp
@@ -2,7 +2,7 @@
 
 #include <Geode/modify/EditorPauseLayer.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 // special class for this because making it a CCMenuItemToggler would be very UB 
 // (not gonna reinterpret_cast that into the members)

--- a/loader/src/ids/EditorUI.cpp
+++ b/loader/src/ids/EditorUI.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/EditorUI.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(EditorUI) {
     setIDSafe(this, 0, "position-slider");

--- a/loader/src/ids/GJGarageLayer.cpp
+++ b/loader/src/ids/GJGarageLayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/GJGarageLayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(GJGarageLayer) {
     setIDSafe(this, 2, "username-label");

--- a/loader/src/ids/LevelBrowserLayer.cpp
+++ b/loader/src/ids/LevelBrowserLayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/LevelBrowserLayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(LevelBrowserLayer) {
     auto winSize = CCDirector::get()->getWinSize();

--- a/loader/src/ids/LevelSettingsLayer.cpp
+++ b/loader/src/ids/LevelSettingsLayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/LevelSettingsLayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(LevelSettingsLayer) {
     bool startPos = m_mainLayer->getChildrenCount() < 10;

--- a/loader/src/ids/MenuLayer.cpp
+++ b/loader/src/ids/MenuLayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <Geode/ui/BasedButtonSprite.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(MenuLayer) {
     // set IDs to everything

--- a/loader/src/ids/PauseLayer.cpp
+++ b/loader/src/ids/PauseLayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/PauseLayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(PauseLayer) {
     setIDs(

--- a/loader/src/ids/UILayer.cpp
+++ b/loader/src/ids/UILayer.cpp
@@ -4,7 +4,7 @@
 #include <Geode/modify/UILayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 $register_ids(UILayer) {
     if (auto menu = getChildOfType<CCMenu>(this, 0)) {

--- a/loader/src/loader/Dirs.cpp
+++ b/loader/src/loader/Dirs.cpp
@@ -4,7 +4,7 @@
 #include <crashlog.hpp>
 #include <filesystem>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 ghc::filesystem::path dirs::getGameDir() {
     return ghc::filesystem::path(CCFileUtils::sharedFileUtils()->getWritablePath2().c_str());

--- a/loader/src/loader/Event.cpp
+++ b/loader/src/loader/Event.cpp
@@ -1,6 +1,6 @@
 #include <Geode/loader/Event.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 void EventListenerProtocol::enable() {
     Event::listeners().insert(this);

--- a/loader/src/loader/Hook.cpp
+++ b/loader/src/loader/Hook.cpp
@@ -7,7 +7,7 @@
 #include "ModImpl.hpp"
 #include "HookImpl.hpp"
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 Hook::Hook(std::shared_ptr<Impl>&& impl) : m_impl(std::move(impl)) {}
 Hook::~Hook() {}

--- a/loader/src/loader/HookImpl.hpp
+++ b/loader/src/loader/HookImpl.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "ModImpl.hpp"
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class Hook::Impl {
 public:

--- a/loader/src/loader/IPC.cpp
+++ b/loader/src/loader/IPC.cpp
@@ -1,7 +1,7 @@
 #include <Geode/loader/IPC.hpp>
 #include <json.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 std::monostate geode::listenForIPC(std::string const& messageID, json::Value(*callback)(IPCEvent*)) {
     (void) new EventListener(

--- a/loader/src/loader/Index.cpp
+++ b/loader/src/loader/Index.cpp
@@ -9,7 +9,7 @@
 #include <Geode/utils/JsonValidation.hpp>
 
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 // ModInstallEvent
 

--- a/loader/src/loader/Loader.cpp
+++ b/loader/src/loader/Loader.cpp
@@ -1,6 +1,6 @@
 #include "LoaderImpl.hpp"
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 Loader::Loader() : m_impl(new Impl) {}
 

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -25,7 +25,7 @@
 #include <thread>
 #include <vector>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 Loader::Impl* LoaderImpl::get() {
     return Loader::get()->m_impl.get();

--- a/loader/src/loader/Log.cpp
+++ b/loader/src/loader/Log.cpp
@@ -9,7 +9,7 @@
 #include <fmt/format.h>
 #include <iomanip>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 using namespace geode::log;
 using namespace cocos2d;
 

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -2,7 +2,7 @@
 #include <Geode/loader/Dirs.hpp>
 #include "ModImpl.hpp"
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 Mod::Mod(ModInfo const& info) : m_impl(std::make_unique<Impl>(this, info)) {}
 

--- a/loader/src/loader/ModEvent.cpp
+++ b/loader/src/loader/ModEvent.cpp
@@ -1,6 +1,6 @@
 #include <Geode/loader/ModEvent.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 ModStateEvent::ModStateEvent(Mod* mod, ModEventType type) : m_mod(mod), m_type(type) {}
 

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 Mod::Impl* ModImpl::getImpl(Mod* mod)  {
     return mod->m_impl.get();

--- a/loader/src/loader/ModInfo.cpp
+++ b/loader/src/loader/ModInfo.cpp
@@ -7,7 +7,7 @@
 #include <about.hpp>
 #include <json.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 bool Dependency::isResolved() const {
     return !this->required ||

--- a/loader/src/loader/Patch.cpp
+++ b/loader/src/loader/Patch.cpp
@@ -1,7 +1,7 @@
 #include <Geode/loader/Hook.hpp>
 #include <json.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 bool Patch::apply() {
     return bool(tulip::hook::writeMemory(m_address, m_patch.data(), m_patch.size()));

--- a/loader/src/loader/Setting.cpp
+++ b/loader/src/loader/Setting.cpp
@@ -9,7 +9,7 @@
 #include <Geode/utils/JsonValidation.hpp>
 #include <re2/re2.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 template<class T>
 static void parseCommon(T& sett, JsonMaybeObject& obj) {

--- a/loader/src/loader/SettingNode.cpp
+++ b/loader/src/loader/SettingNode.cpp
@@ -1,7 +1,7 @@
 #include <Geode/loader/SettingNode.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 void SettingNode::dispatchChanged() {
     if (m_delegate) {

--- a/loader/src/main.cpp
+++ b/loader/src/main.cpp
@@ -11,7 +11,7 @@
 
 #include <array>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 int geodeEntry(void* platformData);
 // platform-specific entry points

--- a/loader/src/platform/Objcpp.mm
+++ b/loader/src/platform/Objcpp.mm
@@ -1,7 +1,7 @@
 // Only a single objc++ file is used because since pch doesnt work, each file adds a lot to the compile times
 #include <Geode/DefaultInclude.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #if defined(GEODE_IS_MACOS)
 

--- a/loader/src/platform/ios/ModImpl.cpp
+++ b/loader/src/platform/ios/ModImpl.cpp
@@ -6,7 +6,7 @@
     #include <loader/ModImpl.hpp>
     #include <dlfcn.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 template <typename T>
 T findSymbolOrMangled(void* dylib, char const* name, char const* mangled) {

--- a/loader/src/platform/ios/util.mm
+++ b/loader/src/platform/ios/util.mm
@@ -3,7 +3,7 @@
 
 #ifdef GEODE_IS_IOS
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
     #include <UIKit/UIKit.h>
     #include <iostream>

--- a/loader/src/platform/mac/LoaderImpl.cpp
+++ b/loader/src/platform/mac/LoaderImpl.cpp
@@ -8,7 +8,7 @@
 
     #include <CoreFoundation/CoreFoundation.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 void Loader::Impl::platformMessageBox(char const* title, std::string const& info) {
     CFStringRef cfTitle = CFStringCreateWithCString(NULL, title, kCFStringEncodingUTF8);

--- a/loader/src/platform/mac/ModImpl.cpp
+++ b/loader/src/platform/mac/ModImpl.cpp
@@ -6,7 +6,7 @@
     #include <loader/ModImpl.hpp>
     #include <dlfcn.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 template <typename T>
 T findSymbolOrMangled(void* dylib, char const* name, char const* mangled) {

--- a/loader/src/platform/mac/util.mm
+++ b/loader/src/platform/mac/util.mm
@@ -3,7 +3,7 @@
 
 #ifdef GEODE_IS_MACOS
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #import <AppKit/AppKit.h>
 #include <Geode/utils/web.hpp>

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -5,7 +5,7 @@
 #include <loader/LoaderImpl.hpp>
 #include <Geode/utils/string.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #ifdef GEODE_IS_WINDOWS
 

--- a/loader/src/platform/windows/ModImpl.cpp
+++ b/loader/src/platform/windows/ModImpl.cpp
@@ -5,7 +5,7 @@
 #include <Geode/loader/Mod.hpp>
 #include <loader/ModImpl.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 template <typename T>
 T findSymbolOrMangled(HMODULE load, char const* name, char const* mangled) {

--- a/loader/src/platform/windows/crashlog.cpp
+++ b/loader/src/platform/windows/crashlog.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <string>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 static bool g_lastLaunchCrashed = false;
 static bool g_symbolsInitialized = false;

--- a/loader/src/platform/windows/nfdwin.hpp
+++ b/loader/src/platform/windows/nfdwin.hpp
@@ -44,7 +44,7 @@
 
 #include <stddef.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 enum class NFDMode {
     OpenFile,

--- a/loader/src/platform/windows/util.cpp
+++ b/loader/src/platform/windows/util.cpp
@@ -3,7 +3,7 @@
 
 #ifdef GEODE_IS_WINDOWS
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #include "nfdwin.hpp"
 #include <ghc/fs_fwd.hpp>

--- a/loader/src/ui/internal/dev/HookListView.hpp
+++ b/loader/src/ui/internal/dev/HookListView.hpp
@@ -3,7 +3,7 @@
 #include <Geode/binding/CustomListView.hpp>
 #include <Geode/binding/TableViewCell.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 static constexpr const BoomListType kBoomListType_Hooks = static_cast<BoomListType>(0x358);
 

--- a/loader/src/ui/internal/dev/HotReloadLayer.hpp
+++ b/loader/src/ui/internal/dev/HotReloadLayer.hpp
@@ -2,7 +2,7 @@
 
 #include <cocos2d.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class HotReloadLayer : public CCLayer {
 protected:

--- a/loader/src/ui/internal/info/DevProfilePopup.hpp
+++ b/loader/src/ui/internal/info/DevProfilePopup.hpp
@@ -2,7 +2,7 @@
 
 #include <Geode/ui/Popup.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class DevProfilePopup : public Popup<std::string const&> {
 protected:

--- a/loader/src/ui/internal/info/ModInfoPopup.hpp
+++ b/loader/src/ui/internal/info/ModInfoPopup.hpp
@@ -7,7 +7,7 @@
 #include <Geode/ui/IconButtonSprite.hpp>
 #include <Geode/loader/Index.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class ModListLayer;
 class ModObject;

--- a/loader/src/ui/internal/info/TagNode.hpp
+++ b/loader/src/ui/internal/info/TagNode.hpp
@@ -2,7 +2,7 @@
 
 #include <cocos2d.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 enum class TagNodeStyle {
     Tag,

--- a/loader/src/ui/internal/list/ModListCell.hpp
+++ b/loader/src/ui/internal/list/ModListCell.hpp
@@ -6,7 +6,7 @@
 #include <Geode/loader/ModInfo.hpp>
 #include <Geode/loader/Index.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class ModListLayer;
 enum class ModListDisplay;

--- a/loader/src/ui/internal/list/ModListLayer.hpp
+++ b/loader/src/ui/internal/list/ModListLayer.hpp
@@ -3,7 +3,7 @@
 #include <Geode/binding/TextInputDelegate.hpp>
 #include <Geode/loader/Index.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class SearchFilterPopup;
 class ModListCell;

--- a/loader/src/ui/internal/list/SearchFilterPopup.hpp
+++ b/loader/src/ui/internal/list/SearchFilterPopup.hpp
@@ -2,7 +2,7 @@
 
 #include <Geode/ui/Popup.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class ModListLayer;
 enum class ModListType;

--- a/loader/src/ui/internal/settings/GeodeSettingNode.hpp
+++ b/loader/src/ui/internal/settings/GeodeSettingNode.hpp
@@ -13,7 +13,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/string.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #define IMPL_SETT_CREATE(type_) \
     static type_##SettingNode* create(              \

--- a/loader/src/ui/internal/settings/ModSettingsPopup.hpp
+++ b/loader/src/ui/internal/settings/ModSettingsPopup.hpp
@@ -4,7 +4,7 @@
 #include <Geode/ui/Popup.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class ModSettingsPopup : public Popup<Mod*>, public SettingNodeDelegate {
 protected:

--- a/loader/src/ui/nodes/BasedButton.cpp
+++ b/loader/src/ui/nodes/BasedButton.cpp
@@ -1,6 +1,6 @@
 #include <Geode/ui/BasedButton.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 TabButton* TabButton::create(
     TabBaseColor unselected, TabBaseColor selected, char const* text, cocos2d::CCObject* target,

--- a/loader/src/ui/nodes/BasedButtonSprite.cpp
+++ b/loader/src/ui/nodes/BasedButtonSprite.cpp
@@ -2,7 +2,7 @@
 #include <Geode/loader/Mod.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 const char* geode::baseEnumToString(CircleBaseSize value) {
     switch (value) {

--- a/loader/src/ui/nodes/ColorPickPopup.cpp
+++ b/loader/src/ui/nodes/ColorPickPopup.cpp
@@ -5,7 +5,7 @@
 #include <Geode/ui/ColorPickPopup.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 static GLubyte parseInt(char const* str) {
     try {

--- a/loader/src/ui/nodes/Colors.cpp
+++ b/loader/src/ui/nodes/Colors.cpp
@@ -2,7 +2,7 @@
 #include <Geode/utils/ranges.hpp>
 #include <Geode/modify/LevelInfoLayer.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 ColorManager::ColorManager() : m_colors({
     { GDColor::NormalModeProgressBar,   {{ ccColor3B { 0,   255, 0   }, Mod::get() }} },

--- a/loader/src/ui/nodes/EnterLayerEvent.cpp
+++ b/loader/src/ui/nodes/EnterLayerEvent.cpp
@@ -1,6 +1,6 @@
 #include <Geode/ui/EnterLayerEvent.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 AEnterLayerEvent::AEnterLayerEvent(
     std::string const& layerID,

--- a/loader/src/ui/nodes/General.cpp
+++ b/loader/src/ui/nodes/General.cpp
@@ -1,7 +1,7 @@
 #include <Geode/ui/General.hpp>
 #include <cocos-ext.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 CCSprite* geode::createLayerBG() {
     auto winSize = CCDirector::get()->getWinSize();

--- a/loader/src/ui/nodes/IconButtonSprite.cpp
+++ b/loader/src/ui/nodes/IconButtonSprite.cpp
@@ -1,7 +1,7 @@
 #include <Geode/ui/IconButtonSprite.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 bool IconButtonSprite::init(
     char const* bg, bool bgIsFrame, cocos2d::CCNode* icon, char const* text, char const* font

--- a/loader/src/ui/nodes/InputNode.cpp
+++ b/loader/src/ui/nodes/InputNode.cpp
@@ -1,7 +1,7 @@
 #include <Geode/binding/CCTextInputNode.hpp>
 #include <Geode/ui/InputNode.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 char const* InputNode::getString() {
     return m_input->getString();

--- a/loader/src/ui/nodes/ListView.cpp
+++ b/loader/src/ui/nodes/ListView.cpp
@@ -5,7 +5,7 @@
 #include <Geode/utils/casts.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 GenericListCell::GenericListCell(char const* name, CCSize size) :
     TableViewCell(name, size.width, size.height) {}

--- a/loader/src/ui/nodes/MDPopup.cpp
+++ b/loader/src/ui/nodes/MDPopup.cpp
@@ -2,7 +2,7 @@
 #include <Geode/ui/MDPopup.hpp>
 #include <Geode/utils/string.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 bool MDPopup::setup(
     std::string const& title, std::string const& info, char const* btn1Text, char const* btn2Text,

--- a/loader/src/ui/nodes/MDTextArea.cpp
+++ b/loader/src/ui/nodes/MDTextArea.cpp
@@ -9,7 +9,7 @@
 #include <Geode/utils/string.hpp>
 #include <md4c.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 static constexpr float g_fontScale = .5f;
 static constexpr float g_paragraphPadding = 7.f;

--- a/loader/src/ui/nodes/Notification.cpp
+++ b/loader/src/ui/nodes/Notification.cpp
@@ -2,7 +2,7 @@
 #include <Geode/loader/Mod.hpp>
 #include <Geode/ui/Notification.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 constexpr auto NOTIFICATION_FADEIN = .3f;
 constexpr auto NOTIFICATION_FADEOUT = 1.f;

--- a/loader/src/ui/nodes/Popup.cpp
+++ b/loader/src/ui/nodes/Popup.cpp
@@ -1,6 +1,6 @@
 #include <Geode/ui/Popup.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 class QuickPopup : public FLAlertLayer, public FLAlertLayerProtocol {
 protected:

--- a/loader/src/ui/nodes/SceneManager.cpp
+++ b/loader/src/ui/nodes/SceneManager.cpp
@@ -1,7 +1,7 @@
 #include <Geode/ui/SceneManager.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 bool SceneManager::setup() {
     m_persistedNodes = CCArray::create();

--- a/loader/src/ui/nodes/ScrollLayer.cpp
+++ b/loader/src/ui/nodes/ScrollLayer.cpp
@@ -1,7 +1,7 @@
 #include <Geode/ui/ScrollLayer.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 GenericContentLayer* GenericContentLayer::create(float width, float height) {
     auto ret = new GenericContentLayer();

--- a/loader/src/ui/nodes/Scrollbar.cpp
+++ b/loader/src/ui/nodes/Scrollbar.cpp
@@ -1,7 +1,7 @@
 #include <Geode/ui/Scrollbar.hpp>
 #include <Geode/utils/cocos.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 bool Scrollbar::ccTouchBegan(CCTouch* touch, CCEvent* event) {
     // hitbox

--- a/loader/src/ui/nodes/TextRenderer.cpp
+++ b/loader/src/ui/nodes/TextRenderer.cpp
@@ -3,7 +3,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/string.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 using namespace std::string_literals;
 
 bool TextDecorationWrapper::init(

--- a/loader/src/utils/JsonValidation.cpp
+++ b/loader/src/utils/JsonValidation.cpp
@@ -1,6 +1,6 @@
 #include <Geode/utils/JsonValidation.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 
 json::Value& JsonMaybeSomething::json() {

--- a/loader/src/utils/PlatformID.cpp
+++ b/loader/src/utils/PlatformID.cpp
@@ -2,7 +2,7 @@
 #include <Geode/platform/platform.hpp>
 #include <Geode/utils/general.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 PlatformID PlatformID::from(const char* str) {
     switch (hash(str)) {

--- a/loader/src/utils/VersionInfo.cpp
+++ b/loader/src/utils/VersionInfo.cpp
@@ -6,7 +6,7 @@
 #include <Geode/utils/general.hpp>
 #include <json.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 // VersionTag
 

--- a/loader/src/utils/cocos.cpp
+++ b/loader/src/utils/cocos.cpp
@@ -2,7 +2,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <json.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 json::Value json::Serialize<ccColor3B>::to_json(ccColor3B const& color) {
     return json::Object {

--- a/loader/src/utils/file.cpp
+++ b/loader/src/utils/file.cpp
@@ -12,7 +12,7 @@
 #include <mz_strm_mem.h>
 #include <mz_zip.h>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 using namespace geode::utils::file;
 
 Result<std::string> utils::file::readString(ghc::filesystem::path const& path) {

--- a/loader/src/utils/string.cpp
+++ b/loader/src/utils/string.cpp
@@ -1,7 +1,7 @@
 #include <Geode/utils/string.hpp>
 #include <algorithm>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #ifdef GEODE_IS_WINDOWS
 

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -5,7 +5,7 @@
 #include <json.hpp>
 #include <thread>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 using namespace web;
 
 namespace geode::utils::fetch {

--- a/loader/test/dependency/main.cpp
+++ b/loader/test/dependency/main.cpp
@@ -1,6 +1,6 @@
 #include <Geode/Loader.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 #include <Geode/modify/MenuLayer.hpp>
 #include <Geode/loader/SettingNode.hpp>

--- a/loader/test/main/main.cpp
+++ b/loader/test/main/main.cpp
@@ -2,7 +2,7 @@
 #include <Geode/loader/ModJsonTest.hpp>
 #include <Geode/loader/ModEvent.hpp>
 
-USE_GEODE_NAMESPACE();
+using namespace geode::prelude;
 
 auto test = []() {
     log::info("Static logged");


### PR DESCRIPTION
Use a namespace instead of polluting globally with a macro.