### PR TITLE
fix GEODE_DISABLE_FMT_CONSTEVAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,14 +69,15 @@ set(GEODE_BIN_PATH ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 set(GEODE_LOADER_PATH ${CMAKE_CURRENT_SOURCE_DIR}/loader)
 set(GEODE_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
-include(cmake/GeodeFile.cmake)
-include(cmake/Platform.cmake)
-include(cmake/CPM.cmake)
+CPMAddPackage("gh:geode-sdk/json#cef9c64")
+CPMAddPackage("gh:fmtlib/fmt#9.1.0")
+CPMAddPackage("gh:gulrak/filesystem#3e5b930")
 
 # this is needed for cross compilation on linux,
 # since fmtlib will fail to compile otherwise
 if (GEODE_DISABLE_FMT_CONSTEVAL)
-	target_compile_definitions(${PROJECT_NAME} INTERFACE -DFMT_CONSTEVAL=)
+	message(VERBOSE "Disabling FMT_CONSTEVAL")
+	target_compile_definitions(fmt PUBLIC -DFMT_CONSTEVAL=)
 endif()
 
 CPMAddPackage("gh:geode-sdk/json#19cf6f4")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,6 @@ if (GEODE_DISABLE_FMT_CONSTEVAL)
 	target_compile_definitions(fmt PUBLIC -DFMT_CONSTEVAL=)
 endif()
 
-CPMAddPackage("gh:geode-sdk/json#19cf6f4")
-CPMAddPackage("gh:fmtlib/fmt#9.1.0")
-CPMAddPackage("gh:gulrak/filesystem#3e5b930")
-
 # Tulip hook (hooking)
 if (PROJECT_IS_TOP_LEVEL AND NOT GEODE_BUILDING_DOCS)
 	set(TULIP_LINK_SOURCE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ CPMAddPackage("gh:gulrak/filesystem#3e5b930")
 # this is needed for cross compilation on linux,
 # since fmtlib will fail to compile otherwise
 if (GEODE_DISABLE_FMT_CONSTEVAL)
-	message(STATUS "Disabling FMT_CONSTEVAL")
+	message(VERBOSE "Disabling FMT_CONSTEVAL")
 	target_compile_definitions(fmt PUBLIC -DFMT_CONSTEVAL=)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ set(GEODE_BIN_PATH ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 set(GEODE_LOADER_PATH ${CMAKE_CURRENT_SOURCE_DIR}/loader)
 set(GEODE_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
+include(cmake/GeodeFile.cmake)
+include(cmake/Platform.cmake)
+include(cmake/CPM.cmake)
+
 CPMAddPackage("gh:geode-sdk/json#cef9c64")
 CPMAddPackage("gh:fmtlib/fmt#9.1.0")
 CPMAddPackage("gh:gulrak/filesystem#3e5b930")
@@ -76,7 +80,7 @@ CPMAddPackage("gh:gulrak/filesystem#3e5b930")
 # this is needed for cross compilation on linux,
 # since fmtlib will fail to compile otherwise
 if (GEODE_DISABLE_FMT_CONSTEVAL)
-	message(VERBOSE "Disabling FMT_CONSTEVAL")
+	message(STATUS "Disabling FMT_CONSTEVAL")
 	target_compile_definitions(fmt PUBLIC -DFMT_CONSTEVAL=)
 endif()
 


### PR DESCRIPTION
Fixes an issue where FMT_CONSTEVAL isn't set properly when enabling GEODE_DISABLE_FMT_CONSTEVAL.