### PR TITLE
add CreatorLayer delegates

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -940,8 +940,7 @@ class CreateMenuItem : CCMenuItemSpriteExtra {
     int m_buildTab;
 }
 
-//TODO: inherits cocos2d::CCSceneTransitionDelegate
-class CreatorLayer : cocos2d::CCLayer {
+class CreatorLayer : cocos2d::CCLayer, cocos2d::CCSceneTransitionDelegate, DialogDelegate {
     void onBack(cocos2d::CCObject*) = win 0x4fae0;
     void onChallenge(cocos2d::CCObject*) = mac 0x142960, win 0x4f1b0;
     void onLeaderboards(cocos2d::CCObject*) = win 0x4ed20;

--- a/loader/include/Geode/cocos/robtop/scene_nodes/CCSceneTransitionDelegate.h
+++ b/loader/include/Geode/cocos/robtop/scene_nodes/CCSceneTransitionDelegate.h
@@ -8,6 +8,7 @@ RT_ADD(
 
 	class CC_DLL CCSceneTransitionDelegate
 	{
+	public:
 		CCSceneTransitionDelegate(const CCSceneTransitionDelegate&);
 		CCSceneTransitionDelegate();
 


### PR DESCRIPTION
Compiling against these updated bindings fixes crashes caused by CreatorLayer:sceneWillResume