### PR TITLE
Replaced the unknown in Slider with the accurate name

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -5465,7 +5465,7 @@ class Slider : cocos2d::CCLayer {
     SliderTouchLogic* m_touchLogic;
     cocos2d::CCSprite* m_sliderBar;
     cocos2d::CCSprite* m_groove;
-    float m_unknown;
+    float m_width;
     float m_height;
 }
 


### PR DESCRIPTION
Note for other occurences, if it's a node and it has 2 floats as fields, 99% of the time it's rob adding the accurate width and height rather than fixing the content size