### PR TITLE
Add SecretLayer2 class to bindings

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -4089,6 +4089,15 @@ class LevelSettingsDelegate {
     virtual void levelSettingsUpdated() {}
 }
 
+class SecretLayer2 : cocos2d::CCLayer, TextInputDelegate, FLAlertLayerProtocol, DialogDelegate {
+    static SecretLayer2* create() = win 0x21FD70;
+
+    bool init() = win 0x21FE10;
+    bool onSubmit(cocos2d::CCObject*) = win 0x221ac0;
+    void updateSearchLabel(const char* text) = win 0x222FC0;
+    void showCompletedLevel() = win 0x220C10;
+}
+
 class SecretLayer4 : cocos2d::CCLayer, TextInputDelegate, FLAlertLayerProtocol, DialogDelegate {
     static SecretLayer4* create() = mac 0x1ed500;
     static cocos2d::CCScene* scene() = mac 0x1ed4c0;


### PR DESCRIPTION
This PR adds the `SecretLayer2` class, which inherits similar classes to `SecretLayer4`.
If there needs to be any changes to this PR, let me know so I can make them.

Credits to @Jouca for the 2 offsets; `onSubmit` & `updateSearchLabel`. The other funcs: `init`, `showCompletedLevel`, `create` by me.