### PR TITLE
Fix misaligned LLM header

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -4275,7 +4275,6 @@ class LocalLevelManager : GManager {
 
     cocos2d::CCDictionary* getAllLevelsInDict() = mac 0x35e3d0, win 0x18d7c0;
 
-    PAD = mac 0x4, win 0x1C;
     cocos2d::CCDictionary* m_loadData;
     cocos2d::CCDictionary* m_levelData;
     cocos2d::CCArray* m_localLevels;


### PR DESCRIPTION
This PR fixes misaligned LLM header that breaks GDShare importing on both Mac and Windows. I also recommend recompiling GDShare itself against these fixed headers to fix this feature, as it currently either does nothing or crashes the game for users.