### PR TITLE
Do not show the update notice for disabled mods + one binding

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -3873,7 +3873,7 @@ class LevelEditorLayer : GJBaseGameLayer, LevelSettingsDelegate {
     cocos2d::CCArray* createObjectsFromString(gd::string, bool) = mac 0x94730, win 0x160980;
     void getLastObjectX() = mac 0x9c860, win 0x167290;
     gd::string getLevelString() = mac 0x97790, win 0x162480;
-    void getNextColorChannel() = mac 0x9a610;
+    int getNextColorChannel() = mac 0x9a610, win 0x164e10;
     void getNextFreeBlockID(cocos2d::CCArray*) = mac 0x9a4e0;
     int getNextFreeGroupID(cocos2d::CCArray*) = mac 0x9a1b0, win 0x164ae0;
     void getNextFreeItemID(cocos2d::CCArray*) = mac 0x9a390;

--- a/loader/src/loader/Index.cpp
+++ b/loader/src/loader/Index.cpp
@@ -594,7 +594,7 @@ bool Index::isUpdateAvailable(IndexItemHandle item) const {
 bool Index::areUpdatesAvailable() const {
     for (auto& mod : Loader::get()->getAllMods()) {
         auto item = this->getMajorItem(mod->getID());
-        if (item && item->getMetadata().getVersion() > mod->getVersion()) {
+        if (item && item->getMetadata().getVersion() > mod->getVersion() && mod->isEnabled()) {
             return true;
         }
     }


### PR DESCRIPTION
This little blue guy doesn't appear if you have updates available only on disabled mods
![image](https://github.com/geode-sdk/geode/assets/61891787/2170b139-c7f6-473f-9972-ef859f5f5215)

Also added LevelEditorLayer::getNextColorChannel to windows and changed its return type to int
