### PR TITLE
fix MoreSearchLayer::create on Mac

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -4354,7 +4354,7 @@ class MenuLayer : cocos2d::CCLayer, FLAlertLayerProtocol, GooglePlayDelegate {
 class MessageListDelegate {}
 
 class MoreSearchLayer : FLAlertLayer {
-    static MoreSearchLayer* create() = mac 0x38ab40, win 0x182520;
+    static MoreSearchLayer* create() = mac 0x388180, win 0x182520;
     virtual bool init() = mac 0x3896b0, win 0x1825c0;
     void onClose(cocos2d::CCObject*) = mac 0x38aa40, win 0x1848f0;
 }


### PR DESCRIPTION
This PR fixes Cvolton/betterinfo-geode#3, which is caused by a bindings error in Geode