### PR TITLE
Add null check for `m_delegate`

### DIFF
--- a/loader/src/hooks/CCTextInputNode.cpp
+++ b/loader/src/hooks/CCTextInputNode.cpp
@@ -15,8 +15,10 @@ struct CCTextInputNodeFix : Modify<CCTextInputNodeFix, CCTextInputNode> {
 		
 		pos += m_textField->getAnchorPoint() * size;
 
-		if(pos.x < 0 || pos.x > size.width || pos.y < 0 || pos.y > size.height) return false;
-		if(!m_delegate->allowTextInput(this)) return false;
+		if (pos.x < 0 || pos.x > size.width || pos.y < 0 || pos.y > size.height)
+			return false;
+		if (!m_delegate->allowTextInput(this))
+			return false;
 
 		this->onClickTrackNode(true);
 

--- a/loader/src/hooks/CCTextInputNode.cpp
+++ b/loader/src/hooks/CCTextInputNode.cpp
@@ -17,7 +17,7 @@ struct CCTextInputNodeFix : Modify<CCTextInputNodeFix, CCTextInputNode> {
 
 		if (pos.x < 0 || pos.x > size.width || pos.y < 0 || pos.y > size.height)
 			return false;
-		if (!m_delegate->allowTextInput(this))
+		if (m_delegate && !m_delegate->allowTextInput(this))
 			return false;
 
 		this->onClickTrackNode(true);

--- a/loader/src/hooks/CCTextInputNode.cpp
+++ b/loader/src/hooks/CCTextInputNode.cpp
@@ -1,0 +1,25 @@
+#include <Geode/modify/CCTextInputNode.hpp>
+
+using namespace geode::prelude;
+
+// rob only uses `CCTextInputNode`s in mostly-flat hierarchies, which still
+// happen to work with the weird vanilla code. this fix makes it work even in
+// deep hierarchies, because the vanilla code uses `getParent` and manually
+// calculates the child location in the world space based on that rather than
+// using `convertToNodeSpace`.
+
+struct CCTextInputNodeFix : Modify<CCTextInputNodeFix, CCTextInputNode> {
+	bool ccTouchBegan(CCTouch* touch, CCEvent* event) {
+		CCPoint pos = this->convertTouchToNodeSpace(touch);
+		CCSize size = this->getContentSize();
+		
+		pos += m_textField->getAnchorPoint() * size;
+
+		if(pos.x < 0 || pos.x > size.width || pos.y < 0 || pos.y > size.height) return false;
+		if(!m_delegate->allowTextInput(this)) return false;
+
+		this->onClickTrackNode(true);
+
+		return true;
+	}
+};


### PR DESCRIPTION
Sometimes this is null (happened on a custom CCTextInputNode for me) and the vanilla code does a check so let's as well.