### PR TITLE
Display messages of unhandled c++ exceptions on Windows

### DIFF
--- a/loader/src/platform/windows/ehdata_structs.hpp
+++ b/loader/src/platform/windows/ehdata_structs.hpp
@@ -1,0 +1,46 @@
+#pragma once
+// All of those are defined in <ehdata.h> but the header fails to compile for some reason.
+
+#define EH_EXCEPTION_NUMBER ('msc' | 0xE0000000)
+
+typedef struct _PMD
+{
+    int mdisp;
+    int pdisp;
+    int vdisp;
+} _PMD;
+
+typedef void (*_PMFN) (void);
+
+#pragma warning (disable:4200)
+#pragma pack (push, _TypeDescriptor, 8)
+typedef struct _TypeDescriptor
+{
+    const void *pVFTable;
+    void *spare;
+    char name [];
+} _TypeDescriptor;
+#pragma pack (pop, _TypeDescriptor)
+#pragma warning (default:4200)
+
+typedef const struct _s__CatchableType {
+    unsigned int properties;
+    _TypeDescriptor *pType;
+    _PMD thisDisplacement;
+    int sizeOrOffset;
+    _PMFN copyFunction;
+} _CatchableType;
+
+#pragma warning (disable:4200)
+typedef const struct _s__CatchableTypeArray {
+    int nCatchableTypes;
+    _CatchableType *arrayOfCatchableTypes [];
+} _CatchableTypeArray;
+#pragma warning (default:4200)
+
+typedef const struct _s__ThrowInfo {
+    unsigned int attributes;
+    _PMFN pmfnUnwind;
+    int (__cdecl *pForwardCompat) (...);
+    _CatchableTypeArray *pCatchableTypeArray;
+} _ThrowInfo;

--- a/loader/src/platform/windows/ehdata_structs.hpp
+++ b/loader/src/platform/windows/ehdata_structs.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-// _ThrowInfo and all of those other structs are hardcoded into MSVC,
+// _ThrowInfo and all of those other structs are hardcoded into MSVC (the compiler itself, unavailable in any header),
 // but don't exist in other compilers like Clang, causing <ehdata.h> to not compile.
 //
-// We check if they don't exist and define them manually.
+// We define them manually in order to be able to use them.
 // source: https://www.geoffchappell.com/studies/msvc/language/predefined/index.htm
 
-#ifndef _ThrowInfo
+#if defined(__GNUC__) || defined(__clang__)
 
 typedef struct _PMD
 {
@@ -50,6 +50,6 @@ typedef const struct _s__ThrowInfo {
     _CatchableTypeArray *pCatchableTypeArray;
 } _ThrowInfo;
 
-#endif // _ThrowInfo
+#endif // defined(__GNUC__) || defined(__clang__)
 
-#include <ehdata.h>
+#include <ehdata.h> // for EH_EXCEPTION_NUMBER

--- a/loader/src/platform/windows/ehdata_structs.hpp
+++ b/loader/src/platform/windows/ehdata_structs.hpp
@@ -1,7 +1,12 @@
 #pragma once
-// All of those are defined in <ehdata.h> but the header fails to compile for some reason.
 
-#define EH_EXCEPTION_NUMBER ('msc' | 0xE0000000)
+// _ThrowInfo and all of those other structs are hardcoded into MSVC,
+// but don't exist in other compilers like Clang, causing <ehdata.h> to not compile.
+//
+// We check if they don't exist and define them manually.
+// source: https://www.geoffchappell.com/studies/msvc/language/predefined/index.htm
+
+#ifndef _ThrowInfo
 
 typedef struct _PMD
 {
@@ -44,3 +49,7 @@ typedef const struct _s__ThrowInfo {
     int (__cdecl *pForwardCompat) (...);
     _CatchableTypeArray *pCatchableTypeArray;
 } _ThrowInfo;
+
+#endif // _ThrowInfo
+
+#include <ehdata.h>

--- a/loader/src/platform/windows/ehdata_structs.hpp
+++ b/loader/src/platform/windows/ehdata_structs.hpp
@@ -6,7 +6,7 @@
 // We define them manually in order to be able to use them.
 // source: https://www.geoffchappell.com/studies/msvc/language/predefined/index.htm
 
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTELLISENSE__)
 
 typedef struct _PMD
 {
@@ -50,6 +50,6 @@ typedef const struct _s__ThrowInfo {
     _CatchableTypeArray *pCatchableTypeArray;
 } _ThrowInfo;
 
-#endif // defined(__GNUC__) || defined(__clang__)
+#endif // defined(__GNUC__) || defined(__clang__) || defined(__INTELLISENSE__)
 
 #include <ehdata.h> // for EH_EXCEPTION_NUMBER


### PR DESCRIPTION
When a C++ exception was thrown from a mod or from Geometry Dash itself, rather than displaying the error code `0xE06D7363`, attempt to also display the error message of the exception.