### PR TITLE
Handle HTTP error responses

### DIFF
--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -271,7 +271,7 @@ SentAsyncWebRequest::Impl::Impl(SentAsyncWebRequest* self, AsyncWebRequest const
         // Follow redirects
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
         // Fail if response code is 4XX or 5XX
-        curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+        curl_easy_setopt(curl, CURLOPT_FAILONERROR, 0L); // we will handle http errors manually
 
         // Headers end
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
@@ -307,11 +307,16 @@ SentAsyncWebRequest::Impl::Impl(SentAsyncWebRequest* self, AsyncWebRequest const
         );
         curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &data);
         auto res = curl_easy_perform(curl);
+        long code = 0;
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
         if (res != CURLE_OK) {
-            long code = 0;
-            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
             curl_easy_cleanup(curl);
             return this->error("Fetch failed: " + std::string(curl_easy_strerror(res)), code);
+        }
+        if (code >= 400 && code < 600) {
+            std::string response_str(ret.begin(), ret.end());
+            curl_easy_cleanup(curl);
+            return this->error(response_str, code);
         }
         curl_easy_cleanup(curl);
 


### PR DESCRIPTION
By default, when an HTTP error code is sent (4XX or 5XX), this will usually result in the message `Fetch failed: HTTP response code said error`

To resolve this, FAILONERROR for curl opts is disabled, and HTTP error codes are handled manually. Instead of the generic response given before (Which doesn't tell anything about what really happened), the response is given instead.

If there needs to be any changes to this PR, let me know so I can make them.