### PR TITLE
Add windows addresses for some LevelTools functions

### DIFF
--- a/bindings/GeometryDash.bro
+++ b/bindings/GeometryDash.bro
@@ -5970,9 +5970,9 @@ class LevelTools {
     static bool verifyLevelIntegrity(gd::string, int) = mac 0x294360, win 0x18b180;
     static float xPosForTime(float, cocos2d::CCArray*, int) = mac 0x293d90, win 0x18acd0;
     static float timeForXPos(float, cocos2d::CCArray*, int) = mac 0x293eb0, win 0x18ae70;
-    static gd::string getAudioFileName(int) = mac 0x292840;
-    static gd::string getAudioTitle(int) = mac 0x2922f0;
-    static gd::string artistForAudio(int) = mac 0x292d90;
-    static gd::string urlForAudio(int) = mac 0x292f10;
+    static gd::string getAudioFileName(int) = mac 0x292840, win 0x189FA0;
+    static gd::string getAudioTitle(int) = mac 0x2922f0, win 0x189C60;
+    static gd::string artistForAudio(int) = mac 0x292d90, win 0x18A2D0;
+    static gd::string urlForAudio(int) = mac 0x292f10, win 0x18A4A0;
 }
 // clang-format on


### PR DESCRIPTION
add windows addresses for LevelTools::getAudioFileName, LevelTools::getAudioTitle, LevelTools::artistForAudio and LevelTools::urlForAudio