### PR TITLE
Refactor logging internals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if (PROJECT_IS_TOP_LEVEL AND NOT GEODE_BUILDING_DOCS)
 	set(MAT_JSON_AS_INTERFACE ON)
 endif()
 CPMAddPackage("gh:geode-sdk/json#a47f570")
-CPMAddPackage("gh:fmtlib/fmt#9.1.0")
+CPMAddPackage("gh:fmtlib/fmt#10.1.1")
 CPMAddPackage("gh:gulrak/filesystem#3e5b930")
 
 target_compile_definitions(${PROJECT_NAME} INTERFACE MAT_JSON_DYNAMIC=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ if (PROJECT_IS_TOP_LEVEL AND NOT GEODE_BUILDING_DOCS)
 	set(MAT_JSON_AS_INTERFACE ON)
 endif()
 CPMAddPackage("gh:geode-sdk/json#a47f570")
-CPMAddPackage("gh:fmtlib/fmt#10.1.1")
+# be careful before updating this! see Log.hpp
+CPMAddPackage("gh:fmtlib/fmt#10.0.0")
 CPMAddPackage("gh:gulrak/filesystem#3e5b930")
 
 target_compile_definitions(${PROJECT_NAME} INTERFACE MAT_JSON_DYNAMIC=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,7 @@ if (PROJECT_IS_TOP_LEVEL AND NOT GEODE_BUILDING_DOCS)
 	set(MAT_JSON_AS_INTERFACE ON)
 endif()
 CPMAddPackage("gh:geode-sdk/json#a47f570")
-# be careful before updating this! see Log.hpp
-CPMAddPackage("gh:fmtlib/fmt#10.0.0")
+CPMAddPackage("gh:fmtlib/fmt#10.1.1")
 CPMAddPackage("gh:gulrak/filesystem#3e5b930")
 
 target_compile_definitions(${PROJECT_NAME} INTERFACE MAT_JSON_DYNAMIC=1)

--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -49,13 +49,13 @@ namespace cocos2d {
 }
 
 namespace gd {
-    inline std::string format_as(gd::string const& value) {
+    GEODE_INLINE GEODE_HIDDEN std::string format_as(gd::string const& value) {
         return value;
     }
 }
 
 namespace ghc::filesystem {
-    inline std::string format_as(ghc::filesystem::path const& value) {
+    GEODE_INLINE GEODE_HIDDEN std::string format_as(ghc::filesystem::path const& value) {
         return value.string();
     }
 }

--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -8,19 +8,16 @@
 #include <ccTypes.h>
 #include <chrono>
 #include <ghc/fs_fwd.hpp>
-#include <sstream>
-#include <vector>
-#include <span>
-
 #include <fmt/core.h>
 
 namespace cocos2d {
-    GEODE_DLL std::string format_as(cocos2d::CCArray*);
+    // ive had enough, fmtlib wont let me do what i want
+    // GEODE_DLL std::string format_as(cocos2d::CCObject*);
+    // GEODE_DLL std::string format_as(cocos2d::CCArray*);
+    // GEODE_DLL std::string format_as(cocos2d::CCNode*);
     GEODE_DLL std::string format_as(cocos2d::ccColor3B const&);
     GEODE_DLL std::string format_as(cocos2d::ccColor4B const&);
     GEODE_DLL std::string format_as(cocos2d::ccColor4F const&);
-    GEODE_DLL std::string format_as(cocos2d::CCNode*);
-    GEODE_DLL std::string format_as(cocos2d::CCObject*);
     GEODE_DLL std::string format_as(cocos2d::CCPoint const&);
     GEODE_DLL std::string format_as(cocos2d::CCRect const&);
     GEODE_DLL std::string format_as(cocos2d::CCSize const&);
@@ -50,51 +47,6 @@ namespace geode {
         using log_clock = std::chrono::system_clock;
         GEODE_DLL std::string generateLogName();
 
-        // Log
-
-        class GEODE_DLL Log final {
-            Mod* m_sender;
-            log_clock::time_point m_time;
-            Severity m_severity;
-            std::string m_content;
-
-            friend class Logger;
-        public:
-            ~Log();
-            Log(Severity sev, Mod* mod, std::string content);
-
-            std::string toString(bool logTime = true) const;
-            std::string toString(bool logTime, uint32_t nestLevel) const;
-
-            std::string const& getContent() const;
-            log_clock::time_point getTime() const;
-            Mod* getSender() const;
-            Severity getSeverity() const;
-        };
-
-        class GEODE_DLL Logger {
-        private:
-            static std::vector<Log>& logs();
-            static std::ofstream& logStream();
-            static uint32_t& nestLevel();
-
-            Logger() = delete;
-            ~Logger() = delete;
-
-            // logs
-        public:
-            static void setup();
-
-            static void push(Log&& log);
-            static void pop(Log* log);
-
-            static void pushNest();
-            static void popNest();
-
-            static std::vector<Log> const& list();
-            static void clear();
-        };
-
         GEODE_DLL void vlogImpl(Severity, Mod*, fmt::string_view format, fmt::format_args args);
 
         template <typename... Args>
@@ -122,11 +74,7 @@ namespace geode {
             logImpl(Severity::Error, getMod(), str, std::forward<Args>(args)...);
         }
 
-        static void pushNest() {
-            Logger::pushNest();
-        }
-        static void popNest() {
-            Logger::popNest();
-        }
+        GEODE_DLL void pushNest();
+        GEODE_DLL void popNest();
     }
 }

--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -12,156 +12,81 @@
 #include <vector>
 #include <span>
 
+#include <fmt/core.h>
+
+namespace cocos2d {
+    GEODE_DLL std::string format_as(cocos2d::CCArray*);
+    GEODE_DLL std::string format_as(cocos2d::ccColor3B const&);
+    GEODE_DLL std::string format_as(cocos2d::ccColor4B const&);
+    GEODE_DLL std::string format_as(cocos2d::ccColor4F const&);
+    GEODE_DLL std::string format_as(cocos2d::CCNode*);
+    GEODE_DLL std::string format_as(cocos2d::CCObject*);
+    GEODE_DLL std::string format_as(cocos2d::CCPoint const&);
+    GEODE_DLL std::string format_as(cocos2d::CCRect const&);
+    GEODE_DLL std::string format_as(cocos2d::CCSize const&);
+}
+
+namespace gd {
+    inline std::string format_as(gd::string const& value) {
+        return value;
+    }
+}
+
+namespace ghc::filesystem {
+    inline std::string format_as(ghc::filesystem::path const& value) {
+        return value.string();
+    }
+}
+
 namespace geode {
 #pragma warning(disable : 4251)
 
     class Mod;
     Mod* getMod();
 
+    GEODE_DLL std::string format_as(Mod*);
+
     namespace log {
         using log_clock = std::chrono::system_clock;
         GEODE_DLL std::string generateLogName();
 
-        // Parse overloads
-        GEODE_DLL std::string parse(cocos2d::CCArray*);
-        GEODE_DLL std::string parse(cocos2d::ccColor3B const&);
-        GEODE_DLL std::string parse(cocos2d::ccColor4B const&);
-        GEODE_DLL std::string parse(cocos2d::ccColor4F const&);
-        GEODE_DLL std::string parse(cocos2d::CCNode*);
-        GEODE_DLL std::string parse(cocos2d::CCObject*);
-        GEODE_DLL std::string parse(cocos2d::CCPoint const&);
-        GEODE_DLL std::string parse(cocos2d::CCRect const&);
-        GEODE_DLL std::string parse(cocos2d::CCSize const&);
-        GEODE_DLL std::string parse(Mod*);
-        GEODE_DLL std::string parse(gd::string const&);
-
-        template <class T>
-            requires std::convertible_to<T*, cocos2d::CCNode*>
-        std::string parse(T* node) {
-            return parse(static_cast<cocos2d::CCNode*>(node));
-        }
-        template <class T>
-            requires(
-                std::convertible_to<T*, cocos2d::CCObject*> &&
-                !std::convertible_to<T*, cocos2d::CCNode*>
-            )
-        std::string parse(T* node) {
-            return parse(static_cast<cocos2d::CCObject*>(node));
-        }
-
-        template <typename T>
-            requires requires(T b) {
-                std::stringstream() << b;
-            }
-        std::string parse(T const& thing) {
-            std::stringstream buf;
-            buf << thing;
-            return buf.str();
-        }
-
-        // todo: maybe add a debugParse function for these?
-
-        template <class T>
-            requires requires(T t) {
-                parse(t);
-            }
-        std::string parse(std::optional<T> const& thing) {
-            if (thing.has_value()) {
-                return "opt(" + parse(thing.value()) + ")";
-            }
-            return "nullopt";
-        }
-
-        template <class T>
-            requires requires(T t) {
-                parse(t);
-            }
-        std::string parse(std::vector<T> const& thing) {
-            std::string res = "[";
-            bool first = true;
-            for (auto& t : thing) {
-                if (!first) {
-                    res += ", ";
-                }
-                first = false;
-                res += parse(t);
-            }
-            res += "]";
-            return res;
-        }
-
-        template <class A, class B>
-            requires requires(A a, B b) {
-                parse(a);
-                parse(b);
-            }
-        std::string parse(std::pair<A, B> const& thing) {
-            return "(" + parse(thing.first) + ", " + parse(thing.second) + ")";
-        }
-
-        template <class... T, std::size_t... Is>
-        std::string parseTupleImpl(std::tuple<T...> const& tuple, std::index_sequence<Is...>) {
-            std::string ret = "(";
-            ((ret += (Is == 0 ? "" : ", ") + parse(std::get<Is>(tuple))), ...);
-            ret += ")";
-            return ret;
-        }
-
-        template <class... T>
-            requires requires(T... t) {
-                (parse(t), ...);
-            }
-        std::string parse(std::tuple<T...> const& tuple) {
-            return parseTupleImpl(tuple, std::index_sequence_for<T...> {});
-        }
-
-        // Log component system
-
-        struct GEODE_DLL ComponentTrait {
-            virtual ~ComponentTrait() {}
-
-            virtual std::string _toString() = 0;
-        };
-
-        template <typename T>
-        struct ComponentBase : public ComponentTrait {
-            T m_item;
-
-            inline ~ComponentBase() override {}
-
-            inline ComponentBase(T const& item) : m_item(item) {}
-
-            // specialization must implement
-            inline std::string _toString() override {
-                return parse(m_item);
-            }
-        };
+        // template <class T>
+        //     requires std::convertible_to<T*, cocos2d::CCNode*>
+        // std::string serialize(T* node) {
+        //     return serialize(static_cast<cocos2d::CCNode*>(node));
+        // }
+        // template <class T>
+        //     requires(
+        //         std::convertible_to<T*, cocos2d::CCObject*> &&
+        //         !std::convertible_to<T*, cocos2d::CCNode*>
+        //     )
+        // std::string serialize(T* node) {
+        //     return serialize(static_cast<cocos2d::CCObject*>(node));
+        // }
 
         // Log
 
         class GEODE_DLL Log final {
             Mod* m_sender;
             log_clock::time_point m_time;
-            std::vector<ComponentTrait*> m_components;
             Severity m_severity;
+            std::string m_content;
 
             friend class Logger;
         public:
             ~Log();
-            Log(Mod* mod, Severity sev);
+            Log(Severity sev, Mod* mod, std::string content);
             Log(Log&& l) = default;
             Log& operator=(Log&& l) = default;
-            bool operator==(Log const& l);
+            // bool operator==(Log const& l) const;
 
             std::string toString(bool logTime = true) const;
             std::string toString(bool logTime, uint32_t nestLevel) const;
 
-            std::vector<ComponentTrait*>& getComponents();
+            std::string const& getContent() const;
             log_clock::time_point getTime() const;
             Mod* getSender() const;
             Severity getSeverity() const;
-
-            Result<> addFormat(std::string_view formatStr, std::span<ComponentTrait*> comps);
         };
 
         class GEODE_DLL Logger {
@@ -187,42 +112,31 @@ namespace geode {
             static void clear();
         };
 
+        GEODE_DLL void vlogImpl(Severity, Mod*, fmt::string_view format, fmt::format_args args);
+
         template <typename... Args>
-            requires requires(Args... b) {
-                (parse(b), ...);
-            }
-        void internalLog(Severity sev, Mod* m, std::string_view formatStr, Args... args) {
-            Log l(m, sev);
-
-            std::array<ComponentTrait*, sizeof...(Args)> comps = { static_cast<ComponentTrait*>(new ComponentBase(args))... };
-            auto res = l.addFormat(formatStr, comps);
-
-            if (res.isErr()) {
-                internalLog(Severity::Warning, getMod(), "Error parsing log format \"{}\": {}", formatStr, res.unwrapErr());
-                return;
-            }
-
-            Logger::push(std::move(l));
+        inline void logImpl(Severity severity, Mod* mod, fmt::format_string<Args...> str, Args&&... args) {
+            vlogImpl(severity, mod, str, fmt::make_format_args(args...));
         }
 
         template <typename... Args>
-        void debug(Args... args) {
-            internalLog(Severity::Debug, getMod(), args...);
+        inline void debug(fmt::format_string<Args...> str, Args&&... args) {
+            logImpl(Severity::Debug, getMod(), str, std::forward<Args>(args)...);
         }
 
         template <typename... Args>
-        void info(Args... args) {
-            internalLog(Severity::Info, getMod(), args...);
+        inline void info(fmt::format_string<Args...> str, Args&&... args) {
+            logImpl(Severity::Info, getMod(), str, std::forward<Args>(args)...);
         }
 
         template <typename... Args>
-        void warn(Args... args) {
-            internalLog(Severity::Warning, getMod(), args...);
+        inline void warn(fmt::format_string<Args...> str, Args&&... args) {
+            logImpl(Severity::Warning, getMod(), str, std::forward<Args>(args)...);
         }
 
         template <typename... Args>
-        void error(Args... args) {
-            internalLog(Severity::Error, getMod(), args...);
+        inline void error(fmt::format_string<Args...> str, Args&&... args) {
+            logImpl(Severity::Error, getMod(), str, std::forward<Args>(args)...);
         }
 
         static void pushNest() {

--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -16,6 +16,8 @@ namespace geode {
     GEODE_DLL std::string format_as(cocos2d::CCObject const*);
     GEODE_DLL std::string format_as(cocos2d::CCArray*);
     GEODE_DLL std::string format_as(cocos2d::CCNode*);
+    class Mod;
+    GEODE_DLL std::string format_as(Mod*);
 }
 
 namespace geode::log::impl {
@@ -25,7 +27,7 @@ namespace geode::log::impl {
     
     template <class T>
     GEODE_INLINE GEODE_HIDDEN decltype(auto) wrapCocosObj(T&& value) {
-        if constexpr (std::is_convertible_v<T, const cocos2d::CCObject*>) {
+        if constexpr (std::is_pointer_v<std::decay_t<T>> && requires(T ptr) { geode::format_as(ptr); }) {
             return geode::format_as(value);
         } else {
             return std::forward<T>(value);
@@ -65,8 +67,6 @@ namespace geode {
 
     class Mod;
     Mod* getMod();
-
-    GEODE_DLL std::string format_as(Mod*);
 
     namespace log {
         using log_clock = std::chrono::system_clock;

--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -23,8 +23,7 @@ namespace geode {
 namespace geode::log::impl {
     // What is this all for? well, fmtlib disallows writing custom formatters for non-void pointer types.
     // So instead, we just wrap everything and pass it a string instead.
-    // WARNING: This code breaks in fmtlib 10.1.1! I have no idea why, so be careful before updating it.
-    
+
     template <class T>
     GEODE_INLINE GEODE_HIDDEN decltype(auto) wrapCocosObj(T&& value) {
         if constexpr (std::is_pointer_v<std::decay_t<T>> && requires(T ptr) { geode::format_as(ptr); }) {
@@ -76,7 +75,9 @@ namespace geode {
 
         template <typename... Args>
         inline void logImpl(Severity severity, Mod* mod, impl::FmtStr<Args...> str, Args&&... args) {
-            vlogImpl(severity, mod, str, fmt::make_format_args(impl::wrapCocosObj(args)...));
+            [&]<typename... Ts>(Ts&&... args) {
+                vlogImpl(severity, mod, str, fmt::make_format_args(args...));
+            }(impl::wrapCocosObj(args)...);
         }
 
         template <typename... Args>

--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -50,20 +50,6 @@ namespace geode {
         using log_clock = std::chrono::system_clock;
         GEODE_DLL std::string generateLogName();
 
-        // template <class T>
-        //     requires std::convertible_to<T*, cocos2d::CCNode*>
-        // std::string serialize(T* node) {
-        //     return serialize(static_cast<cocos2d::CCNode*>(node));
-        // }
-        // template <class T>
-        //     requires(
-        //         std::convertible_to<T*, cocos2d::CCObject*> &&
-        //         !std::convertible_to<T*, cocos2d::CCNode*>
-        //     )
-        // std::string serialize(T* node) {
-        //     return serialize(static_cast<cocos2d::CCObject*>(node));
-        // }
-
         // Log
 
         class GEODE_DLL Log final {
@@ -76,9 +62,6 @@ namespace geode {
         public:
             ~Log();
             Log(Severity sev, Mod* mod, std::string content);
-            Log(Log&& l) = default;
-            Log& operator=(Log&& l) = default;
-            // bool operator==(Log const& l) const;
 
             std::string toString(bool logTime = true) const;
             std::string toString(bool logTime, uint32_t nestLevel) const;
@@ -108,7 +91,7 @@ namespace geode {
             static void pushNest();
             static void popNest();
 
-            static std::vector<Log*> list();
+            static std::vector<Log> const& list();
             static void clear();
         };
 

--- a/loader/include/Geode/utils/VersionInfo.hpp
+++ b/loader/include/Geode/utils/VersionInfo.hpp
@@ -179,8 +179,9 @@ namespace geode {
         }
 
         std::string toString(bool includeTag = true) const;
+
+        friend GEODE_DLL std::string format_as(VersionInfo const& version);
     };
-    GEODE_DLL std::ostream& operator<<(std::ostream& stream, VersionInfo const& version);
 
     class GEODE_DLL ComparableVersionInfo final {
     protected:
@@ -225,8 +226,8 @@ namespace geode {
         }
 
         std::string toString() const;
+        friend GEODE_DLL std::string format_as(ComparableVersionInfo const& version);
     };
-    GEODE_DLL std::ostream& operator<<(std::ostream& stream, ComparableVersionInfo const& version);
 }
 
 template <class V>

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -1,4 +1,4 @@
-#include "loader/LoaderImpl.hpp"
+#include <loader/LoaderImpl.hpp>
 
 #include <Geode/loader/IPC.hpp>
 #include <Geode/loader/Loader.hpp>
@@ -7,6 +7,7 @@
 #include <Geode/loader/SettingEvent.hpp>
 #include <Geode/loader/ModJsonTest.hpp>
 #include <Geode/utils/JsonValidation.hpp>
+#include <loader/LogImpl.hpp>
 
 #include <array>
 
@@ -58,7 +59,7 @@ $execute {
 }
 
 int geodeEntry(void* platformData) {
-    log::Logger::setup();
+    log::Logger::get()->setup();
 
     log::info("Running {} {}", Mod::get()->getName(), Mod::get()->getVersion());
 

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -3,6 +3,7 @@
 
 #include "ModImpl.hpp"
 #include "ModMetadataImpl.hpp"
+#include "LogImpl.hpp"
 
 #include <Geode/loader/Dirs.hpp>
 #include <Geode/loader/IPC.hpp>
@@ -669,7 +670,7 @@ void Loader::Impl::forceReset() {
         delete mod;
     }
     m_mods.clear();
-    log::Logger::clear();
+    log::Logger::get()->clear();
     ghc::filesystem::remove_all(dirs::getModRuntimeDir());
     ghc::filesystem::remove_all(dirs::getTempDir());
 }

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -455,7 +455,7 @@ void Loader::Impl::findProblems() {
             log::debug("{} is not enabled", id);
             continue;
         }
-        log::debug(id);
+        log::debug("{}", id);
         log::pushNest();
 
         for (auto const& dep : mod->getMetadata().getDependencies()) {
@@ -688,7 +688,7 @@ bool Loader::Impl::loadHooks() {
     for (auto const& hook : m_uninitializedHooks) {
         auto res = hook.second->addHook(hook.first);
         if (!res) {
-            log::internalLog(Severity::Error, hook.second, "{}", res.unwrapErr());
+            log::logImpl(Severity::Error, hook.second, "{}", res.unwrapErr());
             hadErrors = true;
         }
     }

--- a/loader/src/loader/Log.cpp
+++ b/loader/src/loader/Log.cpp
@@ -110,11 +110,19 @@ std::string Log::toString(bool logTime) const {
     return toString(logTime, 0);
 }
 
+auto convertTime(auto timePoint) {
+    // std::chrono::current_zone() isnt available on clang (android),
+    // so do this instead to get the local time for logging.
+    // By accident this also gets rid of the decimal places in the seconds
+    auto timeEpoch = std::chrono::system_clock::to_time_t(timePoint);
+    return fmt::localtime(timeEpoch);
+}
+
 std::string Log::toString(bool logTime, uint32_t nestLevel) const {
     std::string res;
 
     if (logTime) {
-        res += fmt::format("{:%H:%M:%S}", std::chrono::floor<std::chrono::seconds>(m_time));
+        res += fmt::format("{:%H:%M:%S}", convertTime(m_time));
     }
 
     switch (m_severity.m_value) {
@@ -216,7 +224,7 @@ void Logger::clear() {
 // Misc
 
 std::string geode::log::generateLogName() {
-    return fmt::format("Geode {:%d %b %H.%M.%S}.log", std::chrono::floor<std::chrono::seconds>(log_clock::now()));
+    return fmt::format("Geode {:%d %b %H.%M.%S}.log", convertTime(log_clock::now()));
 }
 
 void log::pushNest() {

--- a/loader/src/loader/Log.cpp
+++ b/loader/src/loader/Log.cpp
@@ -25,24 +25,23 @@ std::string geode::format_as(Mod* mod) {
     }
 }
 
-#if 0
-std::string cocos2d::format_as(CCObject* obj) {
+std::string geode::format_as(CCObject const* obj) {
     if (obj) {
         // TODO: try catch incase typeid fails
-        return fmt::format("{{ {}, {} }}", typeid(*obj).name(), utils::intToHex(obj));
+        return fmt::format("{{ {}, {} }}", typeid(*obj).name(), fmt::ptr(obj));
     }
     else {
         return "{ CCObject, null }";
     }
 }
 
-std::string cocos2d::format_as(CCNode* obj) {
+std::string geode::format_as(CCNode* obj) {
     if (obj) {
         auto bb = obj->boundingBox();
         return fmt::format(
             "{{ {}, {}, ({}, {} | {} : {}) }}",
             typeid(*obj).name(),
-            utils::intToHex(obj),
+            fmt::ptr(obj),
             bb.origin.x,
             bb.origin.y,
             bb.size.width,
@@ -54,7 +53,7 @@ std::string cocos2d::format_as(CCNode* obj) {
     }
 }
 
-std::string cocos2d::format_as(CCArray* arr) {
+std::string geode::format_as(CCArray* arr) {
     std::string out = "[";
 
     if (arr && arr->count()) {
@@ -67,7 +66,6 @@ std::string cocos2d::format_as(CCArray* arr) {
 
     return out + "]";
 }
-#endif
 
 std::string cocos2d::format_as(CCPoint const& pt) {
     return fmt::format("{}, {}", pt.x, pt.y);

--- a/loader/src/loader/Log.cpp
+++ b/loader/src/loader/Log.cpp
@@ -114,7 +114,7 @@ std::string Log::toString(bool logTime, uint32_t nestLevel) const {
     std::string res;
 
     if (logTime) {
-        res += fmt::format("{:%H:%M:%S}", m_time);
+        res += fmt::format("{:%H:%M:%S}", std::chrono::floor<std::chrono::seconds>(m_time));
     }
 
     switch (m_severity.m_value) {
@@ -216,7 +216,7 @@ void Logger::clear() {
 // Misc
 
 std::string geode::log::generateLogName() {
-    return fmt::format("Geode {:%d %b %H.%M.%S}.log", log_clock::now());
+    return fmt::format("Geode {:%d %b %H.%M.%S}.log", std::chrono::floor<std::chrono::seconds>(log_clock::now()));
 }
 
 void log::pushNest() {

--- a/loader/src/loader/Log.cpp
+++ b/loader/src/loader/Log.cpp
@@ -89,9 +89,11 @@ std::string cocos2d::format_as(cocos2d::ccColor4B const& col) {
 // Log
 
 void log::vlogImpl(Severity sev, Mod* mod, fmt::string_view format, fmt::format_args args) {
-    Log obj(sev, mod, fmt::vformat(format, args));
-
-    Logger::push(std::move(obj));
+    Logger::push(Log(
+        sev,
+        mod,
+        fmt::vformat(format, args)
+    ));
 }
 
 
@@ -101,12 +103,7 @@ Log::Log(Severity sev, Mod* mod, std::string content) :
     m_severity(sev),
     m_content(std::move(content)) {}
 
-Log::~Log() {
-}
-
-// bool Log::operator==(Log const& l) {
-//     return this == &l;
-// }
+Log::~Log() {}
 
 std::string Log::toString(bool logTime) const {
     return toString(logTime, 0);
@@ -219,13 +216,8 @@ void Logger::popNest() {
     nestLevel()--;
 }
 
-std::vector<Log*> Logger::list() {
-    std::vector<Log*> logs_;
-    logs_.reserve(logs().size());
-    for (auto& log : logs()) {
-        logs_.push_back(&log);
-    }
-    return logs_;
+std::vector<Log> const& Logger::list() {
+    return logs();
 }
 
 void Logger::clear() {

--- a/loader/src/loader/LogImpl.hpp
+++ b/loader/src/loader/LogImpl.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Geode/DefaultInclude.hpp>
+#include <Geode/loader/Log.hpp>
+#include <Geode/loader/Mod.hpp>
+#include <vector>
+#include <fstream>
+#include <string>
+
+namespace geode::log {
+    class GEODE_DLL Log final {
+        Mod* m_sender;
+        log_clock::time_point m_time;
+        Severity m_severity;
+        std::string m_content;
+
+    public:
+        ~Log();
+        Log(Severity sev, Mod* mod, std::string&& content);
+
+        std::string toString(bool logTime = true) const;
+        std::string toString(bool logTime, uint32_t nestLevel) const;
+
+        std::string_view getContent() const;
+        log_clock::time_point getTime() const;
+        Mod* getSender() const;
+        Severity getSeverity() const;
+    };
+
+    class Logger {
+    private:
+        std::vector<Log> m_logs;
+        std::ofstream m_logStream;
+        int m_nestLevel;
+
+        Logger() {}
+    public:
+        static Logger* get();
+
+        void setup();
+
+        void push(Severity sev, Mod* mod, std::string&& content);
+        // why would you need this lol
+        // void pop(Log* log);
+
+        void pushNest();
+        void popNest();
+
+        std::vector<Log> const& list();
+        void clear();
+    };
+}

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -158,7 +158,7 @@ Result<> Mod::Impl::loadData() {
                 if (auto setting = this->getSetting(key)) {
                     // load its value
                     if (!setting->load(value.json())) {
-                        log::internalLog(
+                        log::logImpl(
                             Severity::Error,
                             m_self,
                             "{}: Unable to load value for setting \"{}\"",
@@ -168,7 +168,7 @@ Result<> Mod::Impl::loadData() {
                     }
                 }
                 else {
-                    log::internalLog(
+                    log::logImpl(
                         Severity::Warning,
                         m_self,
                         "Encountered unknown setting \"{}\" while loading "
@@ -215,7 +215,7 @@ Result<> Mod::Impl::saveData() {
     for (auto& [key, value] : m_settings) {
         coveredSettings.insert(key);
         if (!value->save(json[key])) {
-            log::error("Unable to save setting \"" + key + "\"");
+            log::error("Unable to save setting \"{}\"", key);
         }
     }
 

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -5,6 +5,7 @@
 #include <loader/ModImpl.hpp>
 #import <Foundation/Foundation.h>
 #include <sys/stat.h>
+#include <loader/LogImpl.hpp>
 
 using namespace geode::prelude;
 
@@ -79,7 +80,7 @@ void Loader::Impl::openPlatformConsole() {
 
     m_platformConsoleOpen = true;
 
-    for (auto const& log : log::Logger::list()) {
+    for (auto const& log : log::Logger::get()->list()) {
         this->logConsoleMessageWithSeverity(log.toString(true), log.getSeverity());
     }
 }

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -80,7 +80,7 @@ void Loader::Impl::openPlatformConsole() {
     m_platformConsoleOpen = true;
 
     for (auto const& log : log::Logger::list()) {
-        this->logConsoleMessageWithSeverity(log->toString(true), log->getSeverity());
+        this->logConsoleMessageWithSeverity(log.toString(true), log.getSeverity());
     }
 }
 

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -75,7 +75,7 @@ void Loader::Impl::openPlatformConsole() {
     m_platformConsoleOpen = true;
 
     for (auto const& log : log::Logger::list()) {
-        this->logConsoleMessageWithSeverity(log->toString(true), log->getSeverity());
+        this->logConsoleMessageWithSeverity(log.toString(true), log.getSeverity());
     }
 }
 

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <loader/LoaderImpl.hpp>
 #include <Geode/utils/string.hpp>
+#include <loader/LogImpl.hpp>
 
 using namespace geode::prelude;
 
@@ -74,7 +75,7 @@ void Loader::Impl::openPlatformConsole() {
 
     m_platformConsoleOpen = true;
 
-    for (auto const& log : log::Logger::list()) {
+    for (auto const& log : log::Logger::get()->list()) {
         this->logConsoleMessageWithSeverity(log.toString(true), log.getSeverity());
     }
 }

--- a/loader/src/ui/nodes/MDTextArea.cpp
+++ b/loader/src/ui/nodes/MDTextArea.cpp
@@ -320,7 +320,7 @@ struct MDParser {
 
             default:
                 {
-                    log::warn("Unhandled text type {}", type);
+                    log::warn("Unhandled text type {}", static_cast<int>(type));
                 }
                 break;
         }
@@ -413,7 +413,7 @@ struct MDParser {
 
             default:
                 {
-                    log::warn("Unhandled block enter type {}", type);
+                    log::warn("Unhandled block enter type {}", static_cast<int>(type));
                 }
                 break;
         }
@@ -516,7 +516,7 @@ struct MDParser {
 
             default:
                 {
-                    log::warn("Unhandled block leave type {}", type);
+                    log::warn("Unhandled block leave type {}", static_cast<int>(type));
                 }
                 break;
         }
@@ -573,7 +573,7 @@ struct MDParser {
 
             default:
                 {
-                    log::warn("Unhandled span enter type {}", type);
+                    log::warn("Unhandled span enter type {}", static_cast<int>(type));
                 }
                 break;
         }
@@ -627,7 +627,7 @@ struct MDParser {
 
             default:
                 {
-                    log::warn("Unhandled span leave type {}", type);
+                    log::warn("Unhandled span leave type {}", static_cast<int>(type));
                 }
                 break;
         }

--- a/loader/src/utils/VersionInfo.cpp
+++ b/loader/src/utils/VersionInfo.cpp
@@ -124,8 +124,8 @@ std::string VersionInfo::toString(bool includeTag) const {
     return fmt::format("v{}.{}.{}", m_major, m_minor, m_patch);
 }
 
-std::ostream& geode::operator<<(std::ostream& stream, VersionInfo const& version) {
-    return stream << version.toString();
+std::string geode::format_as(VersionInfo const& version) {
+    return version.toString();
 }
 
 // ComparableVersionInfo
@@ -179,6 +179,6 @@ std::string ComparableVersionInfo::toString() const {
     return prefix + m_version.toString();
 }
 
-std::ostream& geode::operator<<(std::ostream& stream, ComparableVersionInfo const& version) {
-    return stream << version.toString();
+std::string geode::format_as(ComparableVersionInfo const& version) {
+    return version.toString();
 }


### PR DESCRIPTION
Fixes #369 
- removes LogComponents, now logs just get formatted into a string and saved like that
- Now to define formatting of own type, use fmtlib's api (either format_as or fmt::formatter, see their docs!)
- Breaks ABI (wowie!)
- Usage wise, your code stays the exact same. unless you had defined your own `parser` overload

# TODO
- [x] Refactor Logger class?
- [x] ~~Make Log pimpl?~~ was made hidden instead
