### PR TITLE
Launch Arguments

### DIFF
--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -84,14 +84,12 @@ namespace geode {
         std::vector<LoadProblem> getProblems() const;
 
         /**
-         * Get a launch argument. These can be passed into the game via, for example, 
-         * the "Launch Options" window in Steam.
-         * The format for launch arguments is `-geode:argName=value`.
-         * **Note**: this feature is exclusive to Windows for the time being.
-         * @param arg The argument name
+         * Get a launch argument. These are passed into the game as command-line arguments
+         * with the format `-geode:argName=value`.
+         * @param name The argument name
          * @return The value, if present
-         **/
-        std::optional<std::string> getLaunchArg(std::string_view const arg) const;
+         */
+        std::optional<std::string> getLaunchArgument(std::string_view const name) const;
 
         void queueInMainThread(ScheduledFunction func);
 

--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -83,6 +83,9 @@ namespace geode {
         std::vector<Mod*> getAllMods();
         std::vector<LoadProblem> getProblems() const;
 
+        bool hasLaunchArgs() const;
+        std::optional<std::string> getLaunchArg(std::string_view const arg) const;
+
         void queueInMainThread(ScheduledFunction func);
 
         friend class LoaderImpl;

--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -83,7 +83,6 @@ namespace geode {
         std::vector<Mod*> getAllMods();
         std::vector<LoadProblem> getProblems() const;
 
-        bool hasLaunchArgs() const;
         std::optional<std::string> getLaunchArg(std::string_view const arg) const;
 
         void queueInMainThread(ScheduledFunction func);

--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -94,7 +94,7 @@ namespace geode {
         bool hasLaunchArgument(std::string_view const name) const;
         /**
          * Get a launch argument. These are passed into the game as command-line arguments
-         * with the format `-geode:argName=value`.
+         * with the format `--geode:argName=value`.
          * @param name The argument name
          * @return The value, if present
          */

--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -84,12 +84,27 @@ namespace geode {
         std::vector<LoadProblem> getProblems() const;
 
         /**
+         * Returns the available launch argument names.
+         */
+        std::vector<std::string> getLaunchArgumentNames() const;
+        /**
+         * Returns whether the specified launch argument was passed in via the command line.
+         * @param name The argument name
+         */
+        bool hasLaunchArgument(std::string_view const name) const;
+        /**
          * Get a launch argument. These are passed into the game as command-line arguments
          * with the format `-geode:argName=value`.
          * @param name The argument name
          * @return The value, if present
          */
         std::optional<std::string> getLaunchArgument(std::string_view const name) const;
+        /**
+         * Get a boolean launch argument. Returns whether the argument is present and its
+         * value is exactly `true`.
+         * @param name The argument name
+         */
+        bool getLaunchBool(std::string_view const name) const;
 
         void queueInMainThread(ScheduledFunction func);
 

--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -83,6 +83,14 @@ namespace geode {
         std::vector<Mod*> getAllMods();
         std::vector<LoadProblem> getProblems() const;
 
+        /**
+         * Get a launch argument. These can be passed into the game via, for example, 
+         * the "Launch Options" window in Steam.
+         * The format for launch arguments is `-geode:argName=value`.
+         * **Note**: this feature is exclusive to Windows for the time being.
+         * @param arg The argument name
+         * @return The value, if present
+         **/
         std::optional<std::string> getLaunchArg(std::string_view const arg) const;
 
         void queueInMainThread(ScheduledFunction func);

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -163,7 +163,7 @@ namespace geode {
         /**
          * Get a mod-specific launch argument. This is equivalent to `Loader::getLaunchArgument`
          * with the argument name prefixed by the mod ID. For example, a launch argument named
-         * `modArg` for the mod `author.test` would be specified with `-geode:author.test.modArg=value`.
+         * `modArg` for the mod `author.test` would be specified with `--geode:author.test.modArg=value`.
          * @param name The argument name
          * @return The value, if present
          */

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -150,6 +150,13 @@ namespace geode {
             this->registerCustomSetting(key, std::make_unique<T>(std::string(key), this->getID(), value));
         }
 
+        /**
+         * Get a mod-specific launch argument. This is equivalent to `Loader::getLaunchArg`
+         * except the argument name is prefixed with the mod ID. For example, a launch arg named
+         * `modArg` for the mod `author.test` could be specified with `-geode:author.test.modArg=value`.
+         * @param key The argument name
+         * @return The value, if present
+         */
         std::optional<std::string> getLaunchArg(std::string_view const key) const;
 
         matjson::Value& getSaveContainer();

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -150,6 +150,8 @@ namespace geode {
             this->registerCustomSetting(key, std::make_unique<T>(std::string(key), this->getID(), value));
         }
 
+        std::optional<std::string> getLaunchArg(std::string_view const key) const;
+
         matjson::Value& getSaveContainer();
 
         template <class T>

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -151,13 +151,13 @@ namespace geode {
         }
 
         /**
-         * Get a mod-specific launch argument. This is equivalent to `Loader::getLaunchArg`
-         * except the argument name is prefixed with the mod ID. For example, a launch arg named
-         * `modArg` for the mod `author.test` could be specified with `-geode:author.test.modArg=value`.
-         * @param key The argument name
+         * Get a mod-specific launch argument. This is equivalent to `Loader::getLaunchArgument`
+         * with the argument name prefixed by the mod ID. For example, a launch argument named
+         * `modArg` for the mod `author.test` would be specified with `-geode:author.test.modArg=value`.
+         * @param name The argument name
          * @return The value, if present
          */
-        std::optional<std::string> getLaunchArg(std::string_view const key) const;
+        std::optional<std::string> getLaunchArgument(std::string_view const name) const;
 
         matjson::Value& getSaveContainer();
 

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -151,6 +151,16 @@ namespace geode {
         }
 
         /**
+         * Returns the names of the available mod-specific launch arguments.
+         */
+        std::vector<std::string> getLaunchArgumentNames() const;
+        /**
+         * Equivalent to a prefixed `Loader::hasLaunchArgument` call. See `Mod::getLaunchArgument`
+         * for details about mod-specific launch arguments.
+         * @param name The argument name
+         */
+        bool hasLaunchArgument(std::string_view const name) const;
+        /**
          * Get a mod-specific launch argument. This is equivalent to `Loader::getLaunchArgument`
          * with the argument name prefixed by the mod ID. For example, a launch argument named
          * `modArg` for the mod `author.test` would be specified with `-geode:author.test.modArg=value`.
@@ -158,6 +168,12 @@ namespace geode {
          * @return The value, if present
          */
         std::optional<std::string> getLaunchArgument(std::string_view const name) const;
+        /**
+         * Equivalent to a prefixed `Loader::getLaunchBool` call. See `Mod::getLaunchArgument`
+         * for details about mod-specific launch arguments.
+         * @param name The argument name
+         */
+        bool getLaunchBool(std::string_view const name) const;
 
         matjson::Value& getSaveContainer();
 

--- a/loader/src/loader/Loader.cpp
+++ b/loader/src/loader/Loader.cpp
@@ -76,3 +76,7 @@ void Loader::queueInMainThread(ScheduledFunction func) {
 Mod* Loader::takeNextMod() {
     return m_impl->takeNextMod();
 }
+
+std::optional<std::string> Loader::getLaunchArg(std::string_view const arg) const {
+    return m_impl->getLaunchArg(arg);
+}

--- a/loader/src/loader/Loader.cpp
+++ b/loader/src/loader/Loader.cpp
@@ -77,6 +77,6 @@ Mod* Loader::takeNextMod() {
     return m_impl->takeNextMod();
 }
 
-std::optional<std::string> Loader::getLaunchArg(std::string_view const arg) const {
-    return m_impl->getLaunchArg(arg);
+std::optional<std::string> Loader::getLaunchArgument(std::string_view const name) const {
+    return m_impl->getLaunchArgument(name);
 }

--- a/loader/src/loader/Loader.cpp
+++ b/loader/src/loader/Loader.cpp
@@ -77,6 +77,18 @@ Mod* Loader::takeNextMod() {
     return m_impl->takeNextMod();
 }
 
+std::vector<std::string> Loader::getLaunchArgumentNames() const {
+    return m_impl->getLaunchArgumentNames();
+}
+
+bool Loader::hasLaunchArgument(std::string_view const name) const {
+    return m_impl->hasLaunchArgument(name);
+}
+
 std::optional<std::string> Loader::getLaunchArgument(std::string_view const name) const {
     return m_impl->getLaunchArgument(name);
+}
+
+bool Loader::getLaunchBool(std::string_view const name) const {
+    return m_impl->getLaunchBool(name);
 }

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -736,6 +736,8 @@ void Loader::Impl::releaseNextMod() {
     m_nextModLock.unlock();
 }
 
+// TODO: Support for quoted launch args w/ spaces
+// e.g. "-geode:arg=My spaced value"
 void Loader::Impl::initLaunchArgs() {
     auto launchStr = this->getLaunchString();
     log::debug("Found launch string: {}", launchStr);

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -736,7 +736,7 @@ void Loader::Impl::releaseNextMod() {
     m_nextModLock.unlock();
 }
 
-// TODO: Support for quoted launch args w/ spaces
+// TODO: Support for quoted launch args w/ spaces (this will be backwards compatible)
 // e.g. "-geode:arg=My spaced value"
 void Loader::Impl::initLaunchArguments() {
     auto launchStr = this->getLaunchCommand();
@@ -761,12 +761,25 @@ void Loader::Impl::initLaunchArguments() {
     }
 }
 
+std::vector<std::string> Loader::Impl::getLaunchArgumentNames() const {
+    return map::keys(m_launchArgs);
+}
+
+bool Loader::Impl::hasLaunchArgument(std::string_view const name) const {
+    return m_launchArgs.find(std::string(name)) != m_launchArgs.end();
+}
+
 std::optional<std::string> Loader::Impl::getLaunchArgument(std::string_view const name) const {
     auto value = m_launchArgs.find(std::string(name));
     if (value == m_launchArgs.end()) {
         return std::nullopt;
     }
     return std::optional(value->second);
+}
+
+bool Loader::Impl::getLaunchBool(std::string_view const name) const {
+    auto arg = this->getLaunchArgument(name);
+    return arg.has_value() && arg.value() == "true";
 }
 
 Result<tulip::hook::HandlerHandle> Loader::Impl::getHandler(void* address) {

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -737,7 +737,7 @@ void Loader::Impl::releaseNextMod() {
 }
 
 // TODO: Support for quoted launch args w/ spaces (this will be backwards compatible)
-// e.g. "-geode:arg=My spaced value"
+// e.g. "--geode:arg=My spaced value"
 void Loader::Impl::initLaunchArguments() {
     auto launchStr = this->getLaunchCommand();
     log::debug("Found launch string: {}", launchStr);

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -22,8 +22,11 @@
 #include <fmt/format.h>
 #include <hash.hpp>
 #include <iostream>
+#include <iterator>
+#include <optional>
 #include <resources.hpp>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace geode::prelude;
@@ -66,6 +69,13 @@ void Loader::Impl::createDirectories() {
 Result<> Loader::Impl::setup() {
     if (m_isSetup) {
         return Ok();
+    }
+
+    if (this->supportsLaunchArgs()) {
+        log::debug("Loading launch arguments");
+        log::pushNest();
+        this->initLaunchArgs();
+        log::popNest();
     }
 
     log::debug("Setting up crash handler");
@@ -724,6 +734,38 @@ Mod* Loader::Impl::takeNextMod() {
 void Loader::Impl::releaseNextMod() {
     m_nextMod = nullptr;
     m_nextModLock.unlock();
+}
+
+void Loader::Impl::initLaunchArgs() {
+    auto launchStr = this->getLaunchString();
+    log::debug("Found launch string: {}", launchStr);
+    auto args = string::split(launchStr, " ");
+    for (const auto& arg : args) {
+        if (!arg.starts_with(LAUNCH_ARG_PREFIX)) {
+            continue;
+        }
+        auto pair = arg.substr(LAUNCH_ARG_PREFIX.size());
+        auto sep = pair.find('=');
+        if (sep == std::string::npos) {
+            m_launchArgs.insert({ pair, "true" });
+            continue;
+        }
+        auto key = pair.substr(0, sep);
+        auto value = pair.substr(sep + 1);
+        m_launchArgs.insert({ key, value });
+    }
+    for (const auto& pair : m_launchArgs) {
+        log::debug("Loaded '{}' as '{}'", pair.first, pair.second);
+    }
+}
+
+std::optional<std::string> Loader::Impl::getLaunchArg(std::string_view const arg) const {
+    auto argstr = std::string(arg);
+    auto value = m_launchArgs.find(argstr);
+    if (value == m_launchArgs.end()) {
+        return std::nullopt;
+    }
+    return std::optional(value->second);
 }
 
 Result<tulip::hook::HandlerHandle> Loader::Impl::getHandler(void* address) {

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -71,10 +71,10 @@ Result<> Loader::Impl::setup() {
         return Ok();
     }
 
-    if (this->supportsLaunchArgs()) {
+    if (this->supportsLaunchArguments()) {
         log::debug("Loading launch arguments");
         log::pushNest();
-        this->initLaunchArgs();
+        this->initLaunchArguments();
         log::popNest();
     }
 
@@ -738,8 +738,8 @@ void Loader::Impl::releaseNextMod() {
 
 // TODO: Support for quoted launch args w/ spaces
 // e.g. "-geode:arg=My spaced value"
-void Loader::Impl::initLaunchArgs() {
-    auto launchStr = this->getLaunchString();
+void Loader::Impl::initLaunchArguments() {
+    auto launchStr = this->getLaunchCommand();
     log::debug("Found launch string: {}", launchStr);
     auto args = string::split(launchStr, " ");
     for (const auto& arg : args) {
@@ -761,9 +761,8 @@ void Loader::Impl::initLaunchArgs() {
     }
 }
 
-std::optional<std::string> Loader::Impl::getLaunchArg(std::string_view const arg) const {
-    auto argstr = std::string(arg);
-    auto value = m_launchArgs.find(argstr);
+std::optional<std::string> Loader::Impl::getLaunchArgument(std::string_view const name) const {
+    auto value = m_launchArgs.find(std::string(name));
     if (value == m_launchArgs.end()) {
         return std::nullopt;
     }

--- a/loader/src/loader/LoaderImpl.hpp
+++ b/loader/src/loader/LoaderImpl.hpp
@@ -25,7 +25,7 @@
 
 // TODO: Find a file convention for impl headers
 namespace geode {
-    constexpr std::string LAUNCH_ARG_PREFIX = "-geode:";
+    constexpr std::string LAUNCH_ARG_PREFIX = "--geode:";
 
     class Loader::Impl {
     public:

--- a/loader/src/loader/LoaderImpl.hpp
+++ b/loader/src/loader/LoaderImpl.hpp
@@ -113,10 +113,10 @@ namespace geode {
         std::vector<Mod*> getAllMods();
         std::vector<LoadProblem> getProblems() const;
 
-        bool supportsLaunchArgs() const;
-        std::string getLaunchString();
-        void initLaunchArgs();
-        std::optional<std::string> getLaunchArg(std::string_view const arg) const;
+        bool supportsLaunchArguments() const;
+        std::string getLaunchCommand() const;
+        void initLaunchArguments();
+        std::optional<std::string> getLaunchArgument(std::string_view const name) const;
 
         void updateResources(bool forceReload);
 

--- a/loader/src/loader/LoaderImpl.hpp
+++ b/loader/src/loader/LoaderImpl.hpp
@@ -116,7 +116,10 @@ namespace geode {
         bool supportsLaunchArguments() const;
         std::string getLaunchCommand() const;
         void initLaunchArguments();
+        std::vector<std::string> getLaunchArgumentNames() const;
+        bool hasLaunchArgument(std::string_view const name) const;
         std::optional<std::string> getLaunchArgument(std::string_view const name) const;
+        bool getLaunchBool(std::string_view const name) const;
 
         void updateResources(bool forceReload);
 

--- a/loader/src/loader/LoaderImpl.hpp
+++ b/loader/src/loader/LoaderImpl.hpp
@@ -25,6 +25,8 @@
 
 // TODO: Find a file convention for impl headers
 namespace geode {
+    constexpr std::string LAUNCH_ARG_PREFIX = "-geode:";
+
     class Loader::Impl {
     public:
         mutable std::mutex m_mutex;
@@ -57,6 +59,8 @@ namespace geode {
         int m_refreshingModCount = 0;
         int m_refreshedModCount = 0;
         int m_lateRefreshedModCount = 0;
+
+        std::unordered_map<std::string, std::string> m_launchArgs;
 
         std::chrono::time_point<std::chrono::high_resolution_clock> m_timerBegin;
 
@@ -108,6 +112,11 @@ namespace geode {
         Mod* getLoadedMod(std::string const& id) const;
         std::vector<Mod*> getAllMods();
         std::vector<LoadProblem> getProblems() const;
+
+        bool supportsLaunchArgs() const;
+        std::string getLaunchString();
+        void initLaunchArgs();
+        std::optional<std::string> getLaunchArg(std::string_view const arg) const;
 
         void updateResources(bool forceReload);
 

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -121,8 +121,8 @@ void Mod::registerCustomSetting(std::string_view const key, std::unique_ptr<Sett
     return m_impl->registerCustomSetting(key, std::move(value));
 }
 
-std::optional<std::string> Mod::getLaunchArg(std::string_view const key) const {
-    return m_impl->getLaunchArg(key);
+std::optional<std::string> Mod::getLaunchArgument(std::string_view const name) const {
+    return m_impl->getLaunchArgument(name);
 }
 
 Result<Hook*> Mod::claimHook(std::shared_ptr<Hook> hook) {

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -121,8 +121,20 @@ void Mod::registerCustomSetting(std::string_view const key, std::unique_ptr<Sett
     return m_impl->registerCustomSetting(key, std::move(value));
 }
 
+std::vector<std::string> Mod::getLaunchArgumentNames() const {
+    return m_impl->getLaunchArgumentNames();
+}
+
+bool Mod::hasLaunchArgument(std::string_view const name) const {
+    return m_impl->hasLaunchArgument(name);
+}
+
 std::optional<std::string> Mod::getLaunchArgument(std::string_view const name) const {
     return m_impl->getLaunchArgument(name);
+}
+
+bool Mod::getLaunchBool(std::string_view const name) const {
+    return m_impl->getLaunchBool(name);
 }
 
 Result<Hook*> Mod::claimHook(std::shared_ptr<Hook> hook) {

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -1,6 +1,9 @@
-#include <Geode/loader/Mod.hpp>
-#include <Geode/loader/Dirs.hpp>
 #include "ModImpl.hpp"
+
+#include <Geode/loader/Dirs.hpp>
+#include <Geode/loader/Mod.hpp>
+#include <optional>
+#include <string_view>
 
 using namespace geode::prelude;
 
@@ -72,6 +75,7 @@ ghc::filesystem::path Mod::getResourcesDir() const {
 void Mod::setMetadata(ModMetadata const& metadata) {
     m_impl->setMetadata(metadata);
 }
+
 std::vector<Mod*> Mod::getDependants() const {
     return m_impl->getDependants();
 }
@@ -115,6 +119,10 @@ SettingValue* Mod::getSetting(std::string_view const key) const {
 
 void Mod::registerCustomSetting(std::string_view const key, std::unique_ptr<SettingValue> value) {
     return m_impl->registerCustomSetting(key, std::move(value));
+}
+
+std::optional<std::string> Mod::getLaunchArg(std::string_view const key) const {
+    return m_impl->getLaunchArg(key);
 }
 
 Result<Hook*> Mod::claimHook(std::shared_ptr<Hook> hook) {

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -328,9 +328,9 @@ bool Mod::Impl::hasSetting(std::string_view const key) const {
     return false;
 }
 
-std::optional<std::string> Mod::Impl::getLaunchArg(std::string_view const key) const {
-    auto modKey = m_metadata.getID() + "." + std::string(key);
-    return Loader::get()->getLaunchArg(modKey);
+std::optional<std::string> Mod::Impl::getLaunchArgument(std::string_view const name) const {
+    auto prefixed = m_metadata.getID() + "." + std::string(name);
+    return Loader::get()->getLaunchArgument(prefixed);
 }
 
 // Loading, Toggling, Installing

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -328,6 +328,11 @@ bool Mod::Impl::hasSetting(std::string_view const key) const {
     return false;
 }
 
+std::optional<std::string> Mod::Impl::getLaunchArg(std::string_view const key) const {
+    auto modKey = m_metadata.getID() + "." + std::string(key);
+    return Loader::get()->getLaunchArg(modKey);
+}
+
 // Loading, Toggling, Installing
 
 Result<> Mod::Impl::loadBinary() {

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -328,9 +328,35 @@ bool Mod::Impl::hasSetting(std::string_view const key) const {
     return false;
 }
 
+std::string Mod::Impl::getLaunchArgPrefix() const {
+    return m_metadata.getID() + ".";
+}
+
+std::string Mod::Impl::getLaunchArgName(std::string_view const name) const {
+    return this->getLaunchArgPrefix() + std::string(name);
+}
+
+std::vector<std::string> Mod::Impl::getLaunchArgumentNames() const {
+    auto prefix = getLaunchArgPrefix();
+    std::vector<std::string> names;
+    for (const auto& name : Loader::get()->getLaunchArgumentNames()) {
+        if (name.starts_with(prefix)) {
+            names.push_back(name.substr(prefix.size()));
+        }
+    }
+    return names;
+}
+
+bool Mod::Impl::hasLaunchArgument(std::string_view const name) const {
+    return Loader::get()->hasLaunchArgument(this->getLaunchArgName(name));
+}
+
 std::optional<std::string> Mod::Impl::getLaunchArgument(std::string_view const name) const {
-    auto prefixed = m_metadata.getID() + "." + std::string(name);
-    return Loader::get()->getLaunchArgument(prefixed);
+    return Loader::get()->getLaunchArgument(this->getLaunchArgName(name));
+}
+
+bool Mod::Impl::getLaunchBool(std::string_view const name) const {
+    return Loader::get()->getLaunchBool(this->getLaunchArgName(name));
 }
 
 // Loading, Toggling, Installing

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -113,7 +113,12 @@ namespace geode {
         SettingValue* getSetting(std::string_view const key) const;
         void registerCustomSetting(std::string_view const key, std::unique_ptr<SettingValue> value);
 
+        std::string getLaunchArgPrefix() const;
+        std::string getLaunchArgName(std::string_view const name) const;
+        std::vector<std::string> getLaunchArgumentNames() const;
+        bool hasLaunchArgument(std::string_view const name) const;
         std::optional<std::string> getLaunchArgument(std::string_view const name) const;
+        bool getLaunchBool(std::string_view const name) const;
 
         Result<Hook*> claimHook(std::shared_ptr<Hook> hook);
         Result<> disownHook(Hook* hook);

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -113,7 +113,7 @@ namespace geode {
         SettingValue* getSetting(std::string_view const key) const;
         void registerCustomSetting(std::string_view const key, std::unique_ptr<SettingValue> value);
 
-        std::optional<std::string> getLaunchArg(std::string_view const key) const;
+        std::optional<std::string> getLaunchArgument(std::string_view const name) const;
 
         Result<Hook*> claimHook(std::shared_ptr<Hook> hook);
         Result<> disownHook(Hook* hook);

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -113,6 +113,8 @@ namespace geode {
         SettingValue* getSetting(std::string_view const key) const;
         void registerCustomSetting(std::string_view const key, std::unique_ptr<SettingValue> value);
 
+        std::optional<std::string> getLaunchArg(std::string_view const key) const;
+
         Result<Hook*> claimHook(std::shared_ptr<Hook> hook);
         Result<> disownHook(Hook* hook);
         [[nodiscard]] std::vector<Hook*> getHooks() const;

--- a/loader/src/platform/android/LoaderImpl.cpp
+++ b/loader/src/platform/android/LoaderImpl.cpp
@@ -37,10 +37,10 @@ void Loader::Impl::addNativeBinariesPath(ghc::filesystem::path const& path) {
     log::warn("LoaderImpl::addNativeBinariesPath not implement on this platform, not adding path {}", path.string());
 }
 
-bool Loader::Impl::supportsLaunchArgs() const {
+bool Loader::Impl::supportsLaunchArguments() const {
     return false;
 }
 
-std::string Loader::Impl::getLaunchString() {
+std::string Loader::Impl::getLaunchCommand() const {
     return std::string(); // Empty
 }

--- a/loader/src/platform/android/LoaderImpl.cpp
+++ b/loader/src/platform/android/LoaderImpl.cpp
@@ -36,3 +36,11 @@ bool Loader::Impl::userTriedToLoadDLLs() const {
 void Loader::Impl::addNativeBinariesPath(ghc::filesystem::path const& path) {
     log::warn("LoaderImpl::addNativeBinariesPath not implement on this platform, not adding path {}", path.string());
 }
+
+bool Loader::Impl::supportsLaunchArgs() const {
+    return false;
+}
+
+std::string Loader::Impl::getLaunchString() {
+    return std::string(); // Empty
+}

--- a/loader/src/platform/ios/LoaderImpl.cpp
+++ b/loader/src/platform/ios/LoaderImpl.cpp
@@ -40,10 +40,10 @@ bool Loader::Impl::userTriedToLoadDLLs() const {
     return false;
 }
 
-bool Loader::Impl::supportsLaunchArgs() const {
+bool Loader::Impl::supportsLaunchArguments() const {
     return false;
 }
 
-std::string Loader::Impl::getLaunchString() {
+std::string Loader::Impl::getLaunchCommand() const {
     return std::string(); // Empty
 }

--- a/loader/src/platform/ios/LoaderImpl.cpp
+++ b/loader/src/platform/ios/LoaderImpl.cpp
@@ -39,3 +39,11 @@ void Loader::Impl::setupIPC() {
 bool Loader::Impl::userTriedToLoadDLLs() const {
     return false;
 }
+
+bool Loader::Impl::supportsLaunchArgs() const {
+    return false;
+}
+
+std::string Loader::Impl::getLaunchString() {
+    return std::string(); // Empty
+}

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -147,10 +147,10 @@ std::string Loader::Impl::getGameVersion() {
 }
 
 // TODO
-bool Loader::Impl::supportsLaunchArgs() const {
+bool Loader::Impl::supportsLaunchArguments() const {
     return false;
 }
 
-std::string Loader::Impl::getLaunchString() {
+std::string Loader::Impl::getLaunchCommand() const {
     return std::string(); // Empty
 }

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -145,3 +145,12 @@ void Loader::Impl::addNativeBinariesPath(ghc::filesystem::path const& path) {
 std::string Loader::Impl::getGameVersion() {
     return GEODE_STR(GEODE_GD_VERSION); // TODO implement
 }
+
+// TODO
+bool Loader::Impl::supportsLaunchArgs() const {
+    return false;
+}
+
+std::string Loader::Impl::getLaunchString() {
+    return std::string(); // Empty
+}

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -85,10 +85,10 @@ void Loader::Impl::addNativeBinariesPath(ghc::filesystem::path const& path) {
     AddDllDirectory(path.wstring().c_str());
 }
 
-bool Loader::Impl::supportsLaunchArgs() const {
+bool Loader::Impl::supportsLaunchArguments() const {
     return true;
 }
 
-std::string Loader::Impl::getLaunchString() {
+std::string Loader::Impl::getLauncCommand() {
     return GetCommandLineA();
 }

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -89,6 +89,6 @@ bool Loader::Impl::supportsLaunchArguments() const {
     return true;
 }
 
-std::string Loader::Impl::getLauncCommand() {
+std::string Loader::Impl::getLaunchCommand() const {
     return GetCommandLineA();
 }

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -3,6 +3,7 @@
 #include <loader/ModImpl.hpp>
 #include <loader/LoaderImpl.hpp>
 #include <Geode/utils/string.hpp>
+#include <processenv.h>
 
 using namespace geode::prelude;
 
@@ -82,4 +83,12 @@ void Loader::Impl::addNativeBinariesPath(ghc::filesystem::path const& path) {
         return 0;
     }();
     AddDllDirectory(path.wstring().c_str());
+}
+
+bool Loader::Impl::supportsLaunchArgs() const {
+    return true;
+}
+
+std::string Loader::Impl::getLaunchString() {
+    return GetCommandLineA();
 }

--- a/loader/test/main/main.cpp
+++ b/loader/test/main/main.cpp
@@ -20,6 +20,10 @@ $on_mod(Disabled) {
 }
 $on_mod(Loaded) {
     log::info("Loaded");
+    auto arg = Mod::get()->getLaunchArg("testProp");
+    if (arg.has_value()) {
+        log::info("Test property has value of {}", arg.value());
+    }
 }
 $on_mod(Unloaded) {
     log::info("Unloaded");

--- a/loader/test/main/main.cpp
+++ b/loader/test/main/main.cpp
@@ -20,10 +20,6 @@ $on_mod(Disabled) {
 }
 $on_mod(Loaded) {
     log::info("Loaded");
-    auto arg = Mod::get()->getLaunchArg("testProp");
-    if (arg.has_value()) {
-        log::info("Test property has value of {}", arg.value());
-    }
 }
 $on_mod(Unloaded) {
     log::info("Unloaded");
@@ -90,6 +86,17 @@ struct GJGarageLayerTest : Modify<GJGarageLayerTest, GJGarageLayer> {
         label2->setScale(.4f);
         label2->setZOrder(99999);
         addChild(label2);
+
+        // Launch arguments
+        auto arg = Mod::get()->getLaunchArgument("testArg");
+        auto label3 = CCLabelBMFont::create(
+            fmt::format("Test property: {}", arg.value_or("NOTHING!")).c_str(),
+            "bigFont.fnt"
+        );
+        label3->setPosition(100, 80);
+        label3->setScale(.4f);
+        label3->setZOrder(99999);
+        addChild(label3);
 
         // Dispatch system pt. 1
         // auto fn = Dispatcher::get()->getFunction<void(GJGarageLayer*)>("test-garage-open");

--- a/loader/test/main/main.cpp
+++ b/loader/test/main/main.cpp
@@ -44,6 +44,25 @@ struct $modify(MenuLayer) {
         node->release();
         log::info("ref: {}", ref.lock().data());
 
+        // Launch arguments
+        log::info("Testing launch args...");
+        log::pushNest();
+        log::info("For global context:");
+        log::pushNest();
+        for (const auto& arg : Loader::get()->getLaunchArgumentNames()) {
+            log::info(arg);
+        }
+        log::popNest();
+        log::info("For this mod:");
+        log::pushNest();
+        for (const auto& arg : Mod::get()->getLaunchArgumentNames()) {
+            log::info(arg);
+        }
+        log::popNest();
+        log::info("Mod has launch arg 'modArg': {}", Mod::get()->hasLaunchArgument("modArg"));
+        log::info("Loader bool arg 'boolArg': {}", Loader::get()->getLaunchBool("boolArg"));
+        log::popNest();
+
         return true;
     }
 };
@@ -86,17 +105,6 @@ struct GJGarageLayerTest : Modify<GJGarageLayerTest, GJGarageLayer> {
         label2->setScale(.4f);
         label2->setZOrder(99999);
         addChild(label2);
-
-        // Launch arguments
-        auto arg = Mod::get()->getLaunchArgument("testArg");
-        auto label3 = CCLabelBMFont::create(
-            fmt::format("Test property: {}", arg.value_or("NOTHING!")).c_str(),
-            "bigFont.fnt"
-        );
-        label3->setPosition(100, 80);
-        label3->setScale(.4f);
-        label3->setZOrder(99999);
-        addChild(label3);
 
         // Dispatch system pt. 1
         // auto fn = Dispatcher::get()->getFunction<void(GJGarageLayer*)>("test-garage-open");


### PR DESCRIPTION
This PR adds API methods for accessing loader or mod-specific **launch arguments** passed in via the command-line when running the game. For example, a Steam user can modify their launch arguments in the "Launch Options" tab under "Properties".

Specifically, on both `Loader` and `Mod`, four new methods are accessible in the public API:
- `std::vector<std::string> getLaunchArgumentNames()`
- `bool hasLaunchArgument(std::string_view const name)`
- `std::optional<std::string> getLaunchArgument(std::string_view const name)`
- `bool getLaunchBool(std::string_view const name)`

## Details

The API does not provide access to *every* argument passed in via the command-line. Instead, the loader only reads arguments that are prefixed with `-geode:`. The full format is `-geode:argName=value`.

For example, `-geode:myArg=1234`, `-geode:something=true`, and `-geode:someFlag` are all valid launch arguments, and they would be referenced in the API by their un-prefixed names, i.e. `myArg`, `something`, and `someFlag`.

- Arguments without values (no `=` delimiter) are 'flags' whose values are automatically filled as `true` (plaintext string).
- Arguments can be 'empty', meaning `-geode:emptyArg=` is a valid argument. Their values are empty strings.
- Arguments can be 'booleans', meaning that a call to `getLaunchBool` returns `true` if the value is exactly `true` (plaintext).
  - `getLaunchBool` returns `false` if the value is *anything other than `true`* (or isn't present at all), which could be the subject of further discussion in this PR (perhaps another method returning `std::optional<bool>`?)
- Argument values **cannot** currently have spaces, but a simple solution would be supporting args in the format of `"-geode:stringArg=Some spaced value! Yay!"`, which would be backwards-compatible with existing systems.
- Argument values are string plaintext. In the future, more methods like `getLaunchBool` could be implemented, e.g. `getLaunchInt`.

Additionally, this PR introduces 'mod-specific' launch arguments, which are exactly the same as loader arguments except they're prefixed with the mod ID (and a `.` delimiter). For example, a launch argument named `modArg` for the mod `acikek.fun` would be specified with `-geode:acikek.fun.modArg=yay`.

These details are briefly explained in the doc comments for the added methods, although further elaboration might be needed in the form of a dedicated page in the docs.

## Motivation

There exists an expressed desire to have config options for mods and the loader itself that aren't accessible to the average user. These options might be confusing, experimental, potentially dangerous, or explicitly for debug purposes, and it would be a hassle to help out users who had enabled them on accident.

For example, I have expressed interest in a **loader** option to disable the Geode button in the main menu anticipating an experience a little closer to vanilla. If such an option was accessible via the loader settings menu, then a normal user who toggled it on by accident would have no way to go back and turn it off. 

Furthermore, launch arguments are trivial to debug, as each available argument name and value are logged on startup. If the platform doesn't support launch arguments, nothing is logged.

One can additionally draw parallels to the modded Minecraft community: as users inevitably become more accustomed to modifying config files on disk rather than through an in-game menu, a safer option for future "modpack" creators may be to enable features through launch arguments. Everything about launch arguments signals to an end user: *"hey, don't touch me unless you **really** know what you're doing!"*

## Considerations

Not every platform implemented within Geode has an inherent concept analogous to launch arguments. Android, for example, doesn't expose any of that functionality to the public API. For now, I have only implemented this functionality for Windows, with these considerations:
1. **Making it easy to implement on other platforms.**. You only need to modify `LoaderImpl::supportsLaunchArguments` and `LoaderImpl::getLaunchCommand` -- everything else is handled from there.
2. **Not explicitly relying on the command line**. The `getLaunchCommand` method needs to return a string *analogous* to a launch command, but not exactly sourced from one. The Android launcher could take advantage of this with a text field, for example.
3. **Making the API usable from every platform**. On unsupported platforms, the API doesn't load launch arguments whatsoever, and the API is designed around arguments *maybe* being present, e.g. use of optionals.