### PR TITLE
update fix for GLFW error handler to 2.204

### DIFF
--- a/loader/src/hooks/MessageBoxFix.cpp
+++ b/loader/src/hooks/MessageBoxFix.cpp
@@ -29,10 +29,24 @@ static void __cdecl fixedErrorHandler(int code, char const* description) {
 }
 
 $execute {
-    // TODO: i'm pretty sure this patch only works on 2.113?
-    //(void)Mod::get()->patch(
-    //    reinterpret_cast<void*>(geode::base::getCocos() + 0x19feec), toByteArray(&fixedErrorHandler)
-    //);
+    // updated for 2.204
+    // check xrefs to "GLFWError #%d Happen, %s\n", now there's two functions with the same exact behaviour, one is a member function though...
+	// call ds:MessageBoxW 
+    // patch MessageBoxW to MessageBoxA
+    // geode::base::getCocos() + 0x122600 = MessageBoxA in .idata
+    // geode::base::getCocos() + 0x1225DC = MessageBoxW in .idata
+    const uint32_t importedMessageBoxA = (geode::base::getCocos() + 0x122600);
+    
+    ByteVector p = {
+        (importedMessageBoxA) & 0xff,
+        (importedMessageBoxA >> 8) & 0xff,
+        (importedMessageBoxA >> 16) & 0xff,
+        (importedMessageBoxA >> 24) & 0xff};
+
+    (void)Mod::get()->patch(reinterpret_cast<void*>(geode::base::getCocos() + 0xC75F9), p
+    ); 
+    (void)Mod::get()->patch(reinterpret_cast<void*>(geode::base::getCocos() + 0xc7651), p
+    ); 
 }
 
 #endif

--- a/loader/src/hooks/MessageBoxFix.cpp
+++ b/loader/src/hooks/MessageBoxFix.cpp
@@ -3,6 +3,7 @@
 
 #ifdef GEODE_IS_WINDOWS
 
+    #include <loader/LoaderImpl.hpp>
     #include <Geode/loader/Mod.hpp>
     #include <Geode/modify/Modify.hpp>
 
@@ -35,6 +36,8 @@ $execute {
     // patch MessageBoxW to MessageBoxA
     // geode::base::getCocos() + 0x122600 = MessageBoxA in .idata
     // geode::base::getCocos() + 0x1225DC = MessageBoxW in .idata
+    if (LoaderImpl::get()->isForwardCompatMode()) return;
+
     const uint32_t importedMessageBoxA = geode::base::getCocos() + 0x122600;
 
     ByteVector p = {

--- a/loader/src/hooks/MessageBoxFix.cpp
+++ b/loader/src/hooks/MessageBoxFix.cpp
@@ -30,23 +30,21 @@ static void __cdecl fixedErrorHandler(int code, char const* description) {
 
 $execute {
     // updated for 2.204
-    // check xrefs to "GLFWError #%d Happen, %s\n", now there's two functions with the same exact behaviour, one is a member function though...
-	// call ds:MessageBoxW 
+    // check xrefs to "GLFWError #%d Happen, %s\n", now there's two functions with the same exact
+    // behaviour, one is a member function though... call ds:MessageBoxW
     // patch MessageBoxW to MessageBoxA
     // geode::base::getCocos() + 0x122600 = MessageBoxA in .idata
     // geode::base::getCocos() + 0x1225DC = MessageBoxW in .idata
-    const uint32_t importedMessageBoxA = (geode::base::getCocos() + 0x122600);
-    
+    const uint32_t importedMessageBoxA = geode::base::getCocos() + 0x122600;
+
     ByteVector p = {
         (importedMessageBoxA) & 0xff,
         (importedMessageBoxA >> 8) & 0xff,
         (importedMessageBoxA >> 16) & 0xff,
         (importedMessageBoxA >> 24) & 0xff};
 
-    (void)Mod::get()->patch(reinterpret_cast<void*>(geode::base::getCocos() + 0xC75F9), p
-    ); 
-    (void)Mod::get()->patch(reinterpret_cast<void*>(geode::base::getCocos() + 0xc7651), p
-    ); 
+    (void)Mod::get()->patch(reinterpret_cast<void*>(geode::base::getCocos() + 0xC75F9), p);
+    (void)Mod::get()->patch(reinterpret_cast<void*>(geode::base::getCocos() + 0xc7651), p);
 }
 
 #endif


### PR DESCRIPTION
instead of copying function over, patch call ds:MessageBoxW to call ds:MessageBoxA
this is better because now there's 2 different functions for GLFW error handling(???) and they have different calling conventions

before https://i.imgur.com/HCp7d1v.png
after https://i.imgur.com/zzPELWK.png