### PR TITLE
Refactor console handling

### DIFF
--- a/loader/include/Geode/loader/Log.hpp
+++ b/loader/include/Geode/loader/Log.hpp
@@ -109,7 +109,8 @@ namespace geode {
         private:
             class Impl;
             std::shared_ptr<Nest::Impl> m_impl;
-            friend class Logger;
+            friend GEODE_DLL std::shared_ptr<Nest> saveNest();
+            friend GEODE_DLL void loadNest(std::shared_ptr<Nest> const& nest);
         public:
             explicit Nest(std::shared_ptr<Nest::Impl> impl);
         };

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -19,15 +19,6 @@ using namespace geode::prelude;
 #include "load.hpp"
 
 $execute {
-    listenForSettingChanges("show-platform-console", +[](bool value) {
-        if (value) {
-            console::open();
-        }
-        else {
-            console::close();
-        }
-    });
-    
     ipc::listen("ipc-test", [](ipc::IPCEvent* event) -> matjson::Value {
         return "Hello from Geode!";
     });
@@ -95,7 +86,12 @@ void tryShowForwardCompat() {
 
 int geodeEntry(void* platformData) {
     thread::setName("Main");
+
     log::Logger::get()->setup();
+    console::setup();
+    if (LoaderImpl::get()->isForwardCompatMode()) {
+        console::openIfClosed();
+    }
 
     std::string forwardCompatSuffix;
     if (LoaderImpl::get()->isForwardCompatMode())
@@ -132,10 +128,9 @@ int geodeEntry(void* platformData) {
     tryShowForwardCompat();
 
     // open console
-    if (LoaderImpl::get()->isForwardCompatMode() ||
+    if (!LoaderImpl::get()->isForwardCompatMode() &&
         Mod::get()->getSettingValue<bool>("show-platform-console")) {
-        log::debug("Opening console");
-        console::open();
+        console::openIfClosed();
     }
 
     // set up loader, load mods, etc.

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -678,7 +678,6 @@ std::vector<LoadProblem> Loader::Impl::getProblems() const {
 }
 
 void Loader::Impl::forceReset() {
-    console::close();
     for (auto& [_, mod] : m_mods) {
         delete mod;
     }

--- a/loader/src/loader/LogImpl.hpp
+++ b/loader/src/loader/LogImpl.hpp
@@ -9,46 +9,36 @@
 
 namespace geode::log {
     class Log final {
-        Mod* m_sender;
         log_clock::time_point m_time;
         Severity m_severity;
         std::string m_thread;
+        std::string m_source;
+        int32_t m_nestCount;
         std::string m_content;
 
     public:
         ~Log();
-        Log(Severity sev, std::string&& thread, Mod* mod, std::string&& content);
+        Log(Severity sev, std::string&& thread, std::string&& source, int32_t nestCount,
+            std::string&& content);
 
-        std::string toString(bool logTime = true, int32_t nestCount = 0) const;
+        [[nodiscard]] std::string toString() const;
 
-        std::string_view getContent() const;
-        log_clock::time_point getTime() const;
-        Mod* getSender() const;
-        Severity getSeverity() const;
+        [[nodiscard]] Severity getSeverity() const;
     };
 
     class Logger {
     private:
         std::vector<Log> m_logs;
         std::ofstream m_logStream;
-        inline static thread_local int32_t s_nestLevel;
-        inline static thread_local int32_t s_nestCountOffset;
 
-        Logger() {}
+        Logger() = default;
     public:
         static Logger* get();
 
         void setup();
 
-        void push(Severity sev, Mod* mod, std::string&& content);
-        // why would you need this lol
-        // void pop(Log* log);
-
-        static void pushNest();
-        static void popNest();
-
-        [[nodiscard]] static std::shared_ptr<Nest> saveNest();
-        static void loadNest(std::shared_ptr<Nest> const& nest);
+        void push(Severity sev, std::string&& thread, std::string&& source, int32_t nestCount,
+            std::string&& content);
 
         std::vector<Log> const& list();
         void clear();

--- a/loader/src/loader/console.hpp
+++ b/loader/src/loader/console.hpp
@@ -3,8 +3,15 @@
 #include <string>
 
 namespace geode::console {
-    void open();
-    void close();
+    // intended for setting up an already attached console
+    // for example, if the game was launched with a debugger, it'd already have a console attached
+    // so we can setup that console regardless of the setting
+    void setup();
+    // if the setting is on, we call tryOpenIfClosed, and if there's no console attached yet
+    // (e.g. from a debugger, see above), this function should create a new console
+    // and attach it (perhaps, by calling setup again, see windows impl for an example)
+    void openIfClosed();
+
     void log(std::string const& msg, Severity severity);
     void messageBox(char const* title, std::string const& info, Severity severity = Severity::Error);
 }

--- a/loader/src/platform/android/console.cpp
+++ b/loader/src/platform/android/console.cpp
@@ -17,13 +17,8 @@ namespace {
     }
 }
 
-void console::open() {
-    return;
-}
-
-void console::close() {
-    return;
-}
+void console::setup() { }
+void console::openIfClosed() { }
 
 void console::log(std::string const& msg, Severity severity) {
     __android_log_print(

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -88,7 +88,7 @@ void console::openIfClosed() {
     s_isOpen = true;
 
     for (auto const& log : log::Logger::get()->list()) {
-        console::log(log.toString(true), log.getSeverity());
+        console::log(log.toString(), log.getSeverity());
     }
 }
 

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -46,7 +46,8 @@ void console::log(std::string const& msg, Severity severity) {
 }
 
 
-void console::open() {
+void console::setup() { }
+void console::openIfClosed() {
     if (s_isOpen) return;
 
     std::string outFile = "/tmp/command_output_XXXXXX";
@@ -89,16 +90,6 @@ void console::open() {
     for (auto const& log : log::Logger::get()->list()) {
         console::log(log.toString(true), log.getSeverity());
     }
-}
-
-void console::close() {
-    if (s_isOpen) {
-        ::close(s_platformData.logFd);
-        unlink(s_platformData.logFile.c_str());
-        unlink(s_platformData.scriptFile.c_str());
-    }
-
-    s_isOpen = false;
 }
 
 CFDataRef msgPortCallback(CFMessagePortRef port, SInt32 messageID, CFDataRef data, void* info) {

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -48,7 +48,7 @@ void console::setup() {
     );
 
     for (auto const& log : log::Logger::get()->list()) {
-        console::log(log.toString(true), log.getSeverity());
+        console::log(log.toString(), log.getSeverity());
     }
 }
 

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -116,9 +116,7 @@ void console::setup() {
 
             // count == 0 => not a console and not a file, assume it's closed
             // wine does something weird with /dev/null? not sure tbh but it's definitely up to no good
-            // vscode redirects output to a named pipe and then doesn't use it
-            if (count == 0 || path.ends_with("\\dev\\null") ||
-                string::contains(path, "\\uv\\0000")) {
+            if (count == 0 || path.ends_with("\\dev\\null")) {
                 s_outHandle = nullptr;
                 CloseHandle(GetStdHandle(STD_OUTPUT_HANDLE));
                 CloseHandle(GetStdHandle(STD_INPUT_HANDLE));

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -49,6 +49,9 @@ bool redirectStd(FILE* which, std::string const& name, const Severity sev) {
 }
 
 void console::setup() {
+    // launch args are initialized too late
+    bool forceConsole = ghc::filesystem::exists(dirs::getGameDir() / ".force-console");
+
     bool hasStdout = _fileno(stdout) >= 0;
     if (!s_shouldAlloc) {
         s_origStdOut = hasStdout ? _fdopen(_dup(_fileno(stdout)), "w") : nullptr;
@@ -60,7 +63,7 @@ void console::setup() {
     }
 
     s_outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-    if (!s_outHandle || !hasStdout) {
+    if (!s_outHandle || !hasStdout || forceConsole) {
         if (s_shouldAlloc)
             return;
         if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
@@ -68,7 +71,7 @@ void console::setup() {
             return;
         }
         s_outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (!s_outHandle || !hasStdout) {
+        if (!s_outHandle || !hasStdout || forceConsole) {
             s_shouldAlloc = true;
             return;
         }

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -155,7 +155,7 @@ void console::openIfClosed() {
     if (!s_outHandle) {
         s_outHandle = CreateFileA("CONOUT$", GENERIC_WRITE, 0, nullptr, 0, 0, nullptr);
         SetStdHandle(STD_OUTPUT_HANDLE, s_outHandle);
-        SetStdHandle(STD_INPUT_HANDLE, CreateFileA("CONIN$", GENERIC_WRITE, 0, nullptr, 0, 0, nullptr));
+        SetStdHandle(STD_INPUT_HANDLE, CreateFileA("CONIN$", GENERIC_READ, 0, nullptr, 0, 0, nullptr));
         SetStdHandle(STD_ERROR_HANDLE, s_outHandle);
     }
     setupConsole();

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -1,15 +1,66 @@
 ﻿#include <loader/console.hpp>
 #include <loader/LogImpl.hpp>
+#include <io.h>
 
 using namespace geode::prelude;
 
 HANDLE s_outHandle = nullptr;
+FILE* s_origStdOut = nullptr;
 bool s_hasAnsiColorSupport = false;
 bool s_shouldAlloc = false;
 
+bool redirectStd(FILE* which, std::string const& name, const Severity sev) {
+    auto pipeName = fmt::format(R"(\\.\pipe\geode-{}-{})", name, GetCurrentProcessId());
+    auto pipe = CreateNamedPipeA(
+        pipeName.c_str(),
+        PIPE_ACCESS_INBOUND,
+        PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+        1, 0, 1024, 0, nullptr
+    );
+    if (!pipe) {
+        log::warn("Failed to create pipe, {} will be unavailable", name);
+        return false;
+    }
+    std::thread([pipe, name, sev]() {
+        thread::setName(fmt::format("{} Read Thread", name));
+        std::string cur;
+        while (true) {
+            char buf[1024];
+            DWORD read = 0;
+            if (!ReadFile(pipe, buf, 1024, &read, nullptr))
+                continue;
+            for (auto i = 0; i < read; i++) {
+                if (buf[i] != '\n') {
+                    if (buf[i] != '\r')
+                        cur += buf[i];
+                    continue;
+                }
+                log::Logger::get()->push(sev, "", std::string(name), 0, std::string(cur));
+                cur.clear();
+            }
+        }
+    }).detach();
+    FILE* yum;
+    if (freopen_s(&yum, pipeName.c_str(), "w", which)) {
+        log::warn("Failed to reopen file, {} will be unavailable", name);
+        return false;
+    }
+    return true;
+}
+
 void console::setup() {
+    bool hasStdout = _fileno(stdout) >= 0;
+    if (!s_shouldAlloc) {
+        s_origStdOut = hasStdout ? _fdopen(_dup(_fileno(stdout)), "w") : nullptr;
+        if (!redirectStd(stdout, "stdout", Severity::Info) && s_origStdOut) {
+            fclose(s_origStdOut);
+            s_origStdOut = nullptr;
+        }
+        redirectStd(stderr, "stderr", Severity::Debug);
+    }
+
     s_outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-    if (!s_outHandle) {
+    if (!s_outHandle || !hasStdout) {
         if (s_shouldAlloc)
             return;
         if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
@@ -17,7 +68,7 @@ void console::setup() {
             return;
         }
         s_outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (!s_outHandle) {
+        if (!s_outHandle || !hasStdout) {
             s_shouldAlloc = true;
             return;
         }
@@ -65,6 +116,11 @@ void console::log(std::string const& msg, Severity severity) {
     DWORD written;
 
     if (!s_hasAnsiColorSupport) {
+        if (s_origStdOut) {
+            fwrite(msg.c_str(), 1, msg.size(), s_origStdOut);
+            fwrite("\n", 1, 1, s_origStdOut);
+            fflush(s_origStdOut);
+        }
         WriteConsoleA(s_outHandle, msg.c_str(), msg.size(), &written, nullptr);
         WriteConsoleA(s_outHandle, "\n", 1, &written, nullptr);
         return;
@@ -99,6 +155,11 @@ void console::log(std::string const& msg, Severity severity) {
         "{}{}{}{}\x1b[0m\n",
         colorStr, msg.substr(0, 14), color2Str, msg.substr(14)
     );
+
+    if (s_origStdOut) {
+        fwrite(newMsg.c_str(), 1, newMsg.size(), s_origStdOut);
+        fflush(s_origStdOut);
+    }
     WriteConsoleA(s_outHandle, newMsg.c_str(), newMsg.size(), &written, nullptr);
 }
 


### PR DESCRIPTION
generally works better with debuggers and such on windows now
- console no longer opened/closed in run-time (only opened on startup if enabled)
- log should be fully thread safe now (?)
- windows: the console can now attach to the parent console if ran from cmd or a debugger or whatever
- windows: stdin/stdout are no longer redirected to console, logger uses WriteFile instead
- windows: stdout/stderr are now redirected to logger