### PR TITLE
Fix Visual Studio 2022 Intellisense errors

### DIFF
--- a/loader/include/Geode/cocos/platform/CCPlatformMacros.h
+++ b/loader/include/Geode/cocos/platform/CCPlatformMacros.h
@@ -426,7 +426,7 @@ public:                                                          \
      * but __has_attribute(format) is undefined,
      * leaving CC_FORMAT_PRINTF undefined by default.
      */
-#elif defined(__has_attribute)
+#elif defined(__has_attribute) && !defined(_MSC_VER)
     #if __has_attribute(format)
         #define CC_FORMAT_PRINTF(formatPos, argPos) \
             __attribute__((__format__(printf, formatPos, argPos)))


### PR DESCRIPTION
When opening any .cpp file that includes cocos headers in geode you get the following annoying errors caused by `CC_FORMAT_PRINTF` macro, used in some headers like CCStringh or Common.h

![image](https://github.com/geode-sdk/geode/assets/54410739/1aa806c5-dd18-44af-8f13-e7c298f72eee)

These errors are only part of intellisense and not part of the actual compilation. This is due to the fact that in intellisense `CC_FORMAT_PRINTF` ends up undefined. Just as the comment above says, intellisense defines `__has_attribute` but not `__has__attribute(format)`.

After doing [some research](https://stackoverflow.com/questions/2354784/attribute-formatprintf-1-2-for-msvc) the format attribute doesn't seem to be supported by MSVC anyway so it's better to always define it as an empty macro. 

![image](https://github.com/geode-sdk/geode/assets/54410739/1c79abcb-975c-41e7-b7be-6e22057f565a)
After the fix, the macro is properly defined as empty and the erros disappear