### PR TITLE
Better patching

### DIFF
--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -293,11 +293,7 @@ namespace geode {
             void* address, void* detour, std::string const& displayName,
             tulip::hook::HandlerMetadata const& handlerMetadata,
             tulip::hook::HookMetadata const& hookMetadata
-        ) {
-            auto hook = Hook::create(address, detour, displayName, handlerMetadata, hookMetadata);
-            GEODE_UNWRAP_INTO(auto ptr, this->claimHook(std::move(hook)));
-            return Ok(ptr);
-        }
+        );
 
         /**
          * Claims an existing hook object, marking this mod as its owner.

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -328,10 +328,46 @@ namespace geode {
          * @returns Successful result on success,
          * errorful result with info on error
          */
-        Result<Patch*> patch(void* address, ByteVector const& data) {
-            auto patch = Patch::create(address, data);
-            GEODE_UNWRAP_INTO(auto ptr, this->claimPatch(std::move(patch)));
-            return Ok(ptr);
+        [[deprecated(
+            "It is not recommended to use the patch API directly! "
+            "Consider using the platform-specific versions (patchWindows etc.) instead for clarity"
+        )]]
+        Result<Patch*> patch(void* address, ByteVector const& data);
+
+        template <class Addr>
+        Result<Patch*> patchWindows(Addr addr, ByteVector const& data) {
+            #ifdef GEODE_IS_WINDOWS
+                return this->patch(reinterpret_cast<void*>(addr), data);
+            #else
+                return Err("Attempted to create a patch for Windows");
+            #endif
+        }
+
+        template <class Addr>
+        Result<Patch*> patchMac(Addr addr, ByteVector const& data) {
+            #ifdef GEODE_IS_MACOS
+                return this->patch(reinterpret_cast<void*>(addr), data);
+            #else
+                return Err("Attempted to create a patch for Mac");
+            #endif
+        }
+
+        template <class Addr>
+        Result<Patch*> patchAndroid32(Addr addr, ByteVector const& data) {
+            #ifdef GEODE_IS_ANDROID32
+                return this->patch(reinterpret_cast<void*>(addr), data);
+            #else
+                return Err("Attempted to create a patch for Android32");
+            #endif
+        }
+
+        template <class Addr>
+        Result<Patch*> patchAndroid64(Addr addr, ByteVector const& data) {
+            #ifdef GEODE_IS_ANDROID64
+                return this->patch(reinterpret_cast<void*>(addr), data);
+            #else
+                return Err("Attempted to create a patch for Android64");
+            #endif
         }
 
         /**

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -153,6 +153,12 @@ std::vector<Hook*> Mod::getHooks() const {
     return m_impl->getHooks();
 }
 
+Result<Patch*> Mod::patch(void* address, ByteVector const& data) {
+    auto patch = Patch::create(address, data);
+    GEODE_UNWRAP_INTO(auto ptr, this->claimPatch(std::move(patch)));
+    return Ok(ptr);
+}
+
 Result<Patch*> Mod::claimPatch(std::shared_ptr<Patch> patch) {
     return m_impl->claimPatch(patch);
 }

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -141,6 +141,16 @@ bool Mod::getLaunchFlag(std::string_view const name) const {
     return m_impl->getLaunchFlag(name);
 }
 
+Result<Hook*> Mod::hook(
+    void* address, void* detour, std::string const& displayName,
+    tulip::hook::HandlerMetadata const& handlerMetadata,
+    tulip::hook::HookMetadata const& hookMetadata
+) {
+    auto hook = Hook::create(address, detour, displayName, handlerMetadata, hookMetadata);
+    GEODE_UNWRAP_INTO(auto ptr, this->claimHook(std::move(hook)));
+    return Ok(ptr);
+}
+
 Result<Hook*> Mod::claimHook(std::shared_ptr<Hook> hook) {
     return m_impl->claimHook(hook);
 }


### PR DESCRIPTION
Deprecates the existing `Mod::patch` API and adds platform-specific patching APIs. Reasoning is that since patching is inherently unportable, this reminds modders better that they need to also work out the correct patch for other platforms.

### Unresolved questions
 - [x] Implement platform-specific APIs
 - [x] Add warning to `Mod::patch`
 - [ ] Should the functions issue a warning if you try to call them on another platform?
 - [ ] Should `Mod::patch` be removed completely?