### PR TITLE
Fix Wine crashing when launching via terminal

### DIFF
--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -113,6 +113,19 @@ void console::setup() {
             if (count != 0) {
                 path = std::string(buf, count - 1);
             }
+
+            // count == 0 => not a console and not a file, assume it's closed
+            // wine does something weird with /dev/null? not sure tbh but it's definitely up to no good
+            if ((count == 0 || path.ends_with("\\dev\\null")) && Mod::get()->getSettingValue<bool>("show-platform-console")) {
+                s_outHandle = nullptr;
+                CloseHandle(GetStdHandle(STD_OUTPUT_HANDLE));
+                CloseHandle(GetStdHandle(STD_INPUT_HANDLE));
+                CloseHandle(GetStdHandle(STD_ERROR_HANDLE));
+                FreeConsole();
+                SetStdHandle(STD_OUTPUT_HANDLE, nullptr);
+                SetStdHandle(STD_INPUT_HANDLE, nullptr);
+                SetStdHandle(STD_ERROR_HANDLE, nullptr);
+            }
         }
 
         // clion console supports escape codes but we can't query that because it's a named pipe

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -113,19 +113,6 @@ void console::setup() {
             if (count != 0) {
                 path = std::string(buf, count - 1);
             }
-
-            // count == 0 => not a console and not a file, assume it's closed
-            // wine does something weird with /dev/null? not sure tbh but it's definitely up to no good
-            if (count == 0 || path.ends_with("\\dev\\null")) {
-                s_outHandle = nullptr;
-                CloseHandle(GetStdHandle(STD_OUTPUT_HANDLE));
-                CloseHandle(GetStdHandle(STD_INPUT_HANDLE));
-                CloseHandle(GetStdHandle(STD_ERROR_HANDLE));
-                FreeConsole();
-                SetStdHandle(STD_OUTPUT_HANDLE, nullptr);
-                SetStdHandle(STD_INPUT_HANDLE, nullptr);
-                SetStdHandle(STD_ERROR_HANDLE, nullptr);
-            }
         }
 
         // clion console supports escape codes but we can't query that because it's a named pipe


### PR DESCRIPTION
These lines cause Geode to crash (without any crash logs) when launching Geometry Dash through the terminal. Or `wine GeometryDash.exe`

Removing these lines fixes the issue, though @cgytrus requested that @dankmeme01 & @matcool (also themselves) test it.

Let me know if this causes any issues.