### PR TITLE
fix pch being treated as c files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ add_subdirectory(${GEODE_BINDINGS_REPO_PATH} ${CMAKE_BINARY_DIR}/bindings)
 
 if (NOT GEODE_DISABLE_PRECOMPILED_HEADERS)
 	target_precompile_headers(GeodeBindings INTERFACE
-		"${GEODE_LOADER_PATH}/include/Geode/Bindings.hpp"
+		"$<$<COMPILE_LANGUAGE:CXX>:${GEODE_LOADER_PATH}/include/Geode/Bindings.hpp>"
 	)
 endif()
 
@@ -292,8 +292,8 @@ elseif (EXISTS ${GEODE_PLATFORM_BIN_PATH})
 	target_link_libraries(${PROJECT_NAME} INTERFACE "${GEODE_PLATFORM_BIN_PATH}")
 	if (NOT GEODE_DISABLE_PRECOMPILED_HEADERS)
 		target_precompile_headers(${PROJECT_NAME} INTERFACE
-			"${GEODE_LOADER_PATH}/include/Geode/DefaultInclude.hpp"
-			"${GEODE_LOADER_PATH}/include/Geode/Geode.hpp"
+			"$<$<COMPILE_LANGUAGE:CXX>:${GEODE_LOADER_PATH}/include/Geode/DefaultInclude.hpp>"
+			"$<$<COMPILE_LANGUAGE:CXX>:${GEODE_LOADER_PATH}/include/Geode/Geode.hpp>"
 			# please stop adding modify here its not here because it makes windows compilation take longer than geode 1.0 release date
 		)
 	endif()


### PR DESCRIPTION
This pr fixes cmake treating precompiled headers as C files. CMake generates .c and .h files instead of .cxx and .hxx which causes a compiler error, since precompiled headers get compiled in C mode. So far it seems like I'm the only one that has experienced this issue. The proposed solution is a common practice in cmake, as seen by the [1.1k github search results](https://github.com/search?q=%22target_precompile_headers%22+%3C%24%3CCOMPILE_LANGUAGE%3ACXX%3E+language%3ACMAKE&type=code)