### PR TITLE
Implemented Windows Font Cache fix (again)

### DIFF
--- a/loader/src/hooks/WindowsFontCacheFix.cpp
+++ b/loader/src/hooks/WindowsFontCacheFix.cpp
@@ -1,0 +1,46 @@
+#include <Geode/Geode.hpp>
+
+#ifdef GEODE_IS_WINDOWS
+
+using namespace geode::prelude;
+
+// https://github.com/cocos2d/cocos2d-x/blob/5a25fe75cb8b26b61b14b070e757ec3b17ff7791/cocos2dx/platform/win32/CCImage.cpp#L96
+// stop setFont from caching fonts on Windows
+// Windows Font Cache Manager holds on to them after the app has closed
+// Fonts are supposed to be released in the BitmapDC::~BitmapDC() but this doesn't seem to work consistently?
+// Looks like there's a shared instance of BitmapDC, so presumably it's destructed when the app closes?
+
+int __stdcall AddFontResourceWHook(volatile LPCWSTR p0) {
+    return AddFontResourceExW(p0, FR_PRIVATE, 0);
+}
+
+int __stdcall RemoveFontResourceWHook(volatile LPCWSTR p0) {
+    return RemoveFontResourceExW(p0, FR_PRIVATE, 0);
+}
+
+/*
+ * addr is relative to cocos base
+ * patches x86 CALL at addr to call function at newCall
+ */
+static void patchCall(uintptr_t addr, uintptr_t newCall) {
+    ByteVector patch = { 0xE8 }; // CALL near & relative
+    addr += (uintptr_t)geode::base::getCocos();
+    uintptr_t callAddr = newCall - (addr + 5);
+    for (auto i = 0; i < sizeof(int); ++i)
+        patch.push_back(callAddr >> (8 * i));
+    patch.push_back(0x90); // every overwritten instruction happens to be 6 bytes wide
+    (void)Mod::get()->patch(reinterpret_cast<void*>(addr), patch);
+}
+
+$execute {
+
+    // BitmapDC::~BitmapDC
+    patchCall(0xC9A56, (uintptr_t)&RemoveFontResourceWHook);
+
+    // BitmapDC::setFont
+    patchCall(0xCB5BC, (uintptr_t)&RemoveFontResourceWHook);
+    patchCall(0xCB642, (uintptr_t)&AddFontResourceWHook);
+
+};
+
+#endif


### PR DESCRIPTION
I opened an earlier PR but it was a train-wreck so I'm back again with one that shouldn't be hot garbage (maybe just normal garbage). Anyway most of this is copied over:

## Problem

For whatever reason, in my experience on all of my Windows systems with very basic testing using CCLabelTTF, cocos does not properly remove user provided (via TTF file) font resources from the font table. After closing the app, any user-provided font files are impossible to delete without killing the Windows Font Cache Service. This makes it impossible to delete the respective mod's active save directory (or "temp dir"), which causes a whole host of other problems (uninstalling the mod, updating the mod, uninstalling Geode, etc).

The implementation causing the problems in question should be [here](https://github.com/cocos2d/cocos2d-x/blob/cocos2d-x-2.2.3/cocos2dx/platform/win32/CCImage.cpp). I don't particularly see anything wrong with it but I'm definitely having problems.
Fix

All the fix does is hook [BitmapDC::setFont](https://github.com/cocos2d/cocos2d-x/blob/5a25fe75cb8b26b61b14b070e757ec3b17ff7791/cocos2dx/platform/win32/CCImage.cpp#L96) so that it immediately releases any user-provided (in the active save directory) fonts. I haven't had any performance issues with this, but if issues are a concern, I could easily implement an alternate implementation that keeps track of added user fonts and releases them whenever the app closes or crashes, but any unexpected behavior beyond what Geode's crash handler can handle would cause problems.

Regardless, assuming I'm not misusing them, I think a fix for this issue ought to be included in the loader or some other part of the framework because having to include Windows-specific fixes on a mod-by-mod basis any time TTF labels are used doesn't line up with Geode's cross-platform goals.

## Reproducing the Issue

The minimal code that caused this problem for me was the following. I hope I'm not misusing CCLabelTTF here.

class $modify(MenuLayer) {
    bool init() {
        if (!MenuLayer::init()) return false;
        auto label = CCLabelTTF::create("Hello World", "Font.ttf"_spr, 50.0f);
        this->addChild(label);
    }
}

To reproduce with the above code:

* Build the mod
* Run the game with the mod enabled (if the text that appears isn't of the font you provided, the issue won't be reproduced)
* Close the game
* Rebuild the mod
* Run the game again
* And then for me, I get an error as Geode is unable to delete the "temp dir."

## Fix Attempt

Patch calls to `AddFontResourceW` and `RemoveFontResourceW`, made in the `BitmapDC::~BitmapDC` and `BitmapDC::setFont` functions, to call their respective extended versions with the `FR_PRIVATE` flag set, so that Windows releases the font resources whenever the app terminates.

## TODO

* This "fix" has worked for me like 99% of the time but I've had one single instance where it failed (notably the file was marked as open by "System" instead of the Font Cache Service) which I've been unable to reproduce. So if anybody knows anything about that...
* More testing; need to experiment with switching between multiple fonts at runtime to ensure every patch is hit