### PR TITLE
Implement "Report Issue" button

### DIFF
--- a/loader/src/ui/internal/GeodeUI.cpp
+++ b/loader/src/ui/internal/GeodeUI.cpp
@@ -23,7 +23,16 @@ void geode::openIssueReportPopup(Mod* mod) {
                 dirs::getCrashlogsDir().string() + "`",
             "OK", "Open Folder",
             [mod](bool btn2) {
-                file::openFolder(dirs::getCrashlogsDir());
+                if (btn2) {
+                    file::openFolder(dirs::getCrashlogsDir());
+                    return;
+                } 
+
+                auto issues = mod->getMetadata().getIssues();
+                if (issues && issues.value().url) {
+                    auto url = issues.value().url.value();
+                    web::openLinkInBrowser(url);
+                }
             }
         )->show();
     }


### PR DESCRIPTION
Currently, "Report an Issue" button, which can be found in the `ModInfoPopup` if `mod.json` contains `issues` property, doesn't do anything useful except opening crashlog directory. This changes it to actually open the specified URL in browser / crashlogs directory, instead of both buttons having the same action.