### PR TITLE
change #warning to #pragma message for visual studio

### DIFF
--- a/loader/include/Geode/Enums.hpp
+++ b/loader/include/Geode/Enums.hpp
@@ -4,7 +4,7 @@ struct TodoReturnPlaceholder;
 
 #ifdef GEODE_REVERT_TODO_RETURN
     using TodoReturn = void;
-    #warning "Reverting TodoReturn to void. This behavior is deprecated and will be removed in a later update."
+    #pragma message("Reverting TodoReturn to void. This behavior is deprecated and will be removed in a later update.")
 #else
     #define GEODE_REVERT_TODO_RETURN 0
     using TodoReturn = TodoReturnPlaceholder;


### PR DESCRIPTION
msvc doesn't like `#warning` for whatever reason, so GEODE_REVERT_TODO_RETURN just can't be used