### PR TITLE
[Loader] Enable 'MZ_FORCE_FETCH_LIBS'

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -17,6 +17,12 @@ else()
 	set(PROJECT_VERSION_SUFFIX "")
 endif()
 
+# I think CMake is trying to link zlib from the host system?
+# This prevents it from doing that.
+if (CMAKE_CROSSCOMPILING)
+	set(MZ_FORCE_FETCH_LIBS ON)
+endif()
+
 # https://stackoverflow.com/a/63924044/9124836
 # https://stackoverflow.com/a/72396471
 execute_process(


### PR DESCRIPTION
I think CMake is trying to link zlib from the host system? This prevents it from doing that.

This also causes a fun new CMake warning when configuring for whatever reason.