### PR TITLE
[Loader] Correct rendering of soft line breaks in MDTextArea

### DIFF
--- a/loader/src/ui/nodes/MDTextArea.cpp
+++ b/loader/src/ui/nodes/MDTextArea.cpp
@@ -243,7 +243,7 @@ struct MDParser {
 
             case MD_TEXTTYPE::MD_TEXT_SOFTBR:
                 {
-                    renderer->breakLine();
+                    renderer->renderString(" ");
                 }
                 break;
 


### PR DESCRIPTION
This was pissing me off so I fixed it