### PR TITLE
Fix loading bar going out of bounds

### DIFF
--- a/loader/src/hooks/LoadingLayer.cpp
+++ b/loader/src/hooks/LoadingLayer.cpp
@@ -146,13 +146,27 @@ struct CustomLoadingLayer : Modify<CustomLoadingLayer, LoadingLayer> {
         LoaderImpl::get()->updateResources(true);
         this->continueLoadAssets();
     }
+
+    int getLoadedMods() {
+        auto allMods = Loader::get()->getAllMods();
+        return std::count_if(allMods.begin(), allMods.end(), [&](auto& item) {
+            return item->isEnabled();
+        });
+    }
+
+    int getEnabledMods() {
+        auto allMods = Loader::get()->getAllMods();
+        return std::count_if(allMods.begin(), allMods.end(), [&](auto& item) {
+            return item->shouldLoad();
+        });
+    }
     
     int getCurrentStep() {
-        return m_fields->m_geodeLoadStep + m_loadStep + 1 + LoaderImpl::get()->m_refreshedModCount;
+        return m_fields->m_geodeLoadStep + m_loadStep + getLoadedMods();
     }
 
     int getTotalStep() {
-        return 18 + m_fields->m_totalMods;
+        return 3 + 14 + getEnabledMods();
     }
 
     void updateLoadingBar() {


### PR DESCRIPTION
The actual reason lies in the loader implementation, which for some reason can sometimes count up the `m_refreshedModCount` twice for some mods which are disabled.

This small change checks the actual loaded mod count instead of relying on an incorrect `LoaderImpl` member and fixes issue #687.