### PR TITLE
Add handling of unused keys and mouse buttons, rewrite numpad input

### DIFF
--- a/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h
+++ b/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h
@@ -200,13 +200,15 @@ RT_ADD(
 
         // Geode additions
         KEY_GraveAccent = 0x1000,
-        KEY_Equal = 0x1001,
+        KEY_OEMEqual = 0x1001,
         KEY_LeftBracket = 0x1002,
         KEY_RightBracket = 0x1003,
         KEY_Backslash = 0x1004,
         KEY_Semicolon = 0x1005,
         KEY_Apostrophe = 0x1006,
         KEY_Slash = 0x1007,
+        KEY_Equal = 0x1008,
+        KEY_NumEnter = 0x1009,
         MOUSE_4 = 0x1100,
         MOUSE_5 = 0x1101,
         MOUSE_6 = 0x1102,

--- a/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h
+++ b/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h
@@ -209,6 +209,11 @@ RT_ADD(
         KEY_Slash = 0x1007,
         KEY_Equal = 0x1008,
         KEY_NumEnter = 0x1009,
+        // Keys used by some non-US keyboard layouts
+        KEY_World1 = 0x100A,
+        KEY_World2 = 0x100B,
+
+        // Mouse buttons (excluding clicks)
         MOUSE_4 = 0x1100,
         MOUSE_5 = 0x1101,
         MOUSE_6 = 0x1102,

--- a/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h
+++ b/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h
@@ -14,7 +14,6 @@ RT_ADD(
 	*/
     typedef enum
     {
-        // this one might not actually exist in gd itself
         KEY_Unknown = -0x01,
         KEY_None = 0x00,
         KEY_Backspace = 0x08,
@@ -198,6 +197,21 @@ RT_ADD(
         CONTROLLER_RTHUMBSTICK_DOWN = 0x40F,
         CONTROLLER_RTHUMBSTICK_LEFT = 0x411,
         CONTROLLER_RTHUMBSTICK_RIGHT = 0x413,
+
+        // Geode additions
+        KEY_GraveAccent = 0x1000,
+        KEY_Equal = 0x1001,
+        KEY_LeftBracket = 0x1002,
+        KEY_RightBracket = 0x1003,
+        KEY_Backslash = 0x1004,
+        KEY_Semicolon = 0x1005,
+        KEY_Apostrophe = 0x1006,
+        KEY_Slash = 0x1007,
+        MOUSE_4 = 0x1100,
+        MOUSE_5 = 0x1101,
+        MOUSE_6 = 0x1102,
+        MOUSE_7 = 0x1103,
+        MOUSE_8 = 0x1104
     } enumKeyCodes;
 
 	class CC_DLL CCKeyboardDelegate

--- a/loader/src/hooks/AddExtraKeys.cpp
+++ b/loader/src/hooks/AddExtraKeys.cpp
@@ -1,3 +1,5 @@
+#ifdef GEODE_IS_DESKTOP
+
 #include <Geode/DefaultInclude.hpp>
 #include <Geode/cocos/robtop/glfw/glfw3.h>
 #include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDispatcher.h>
@@ -8,7 +10,6 @@
 #include <Geode/modify/CCKeyboardDispatcher.hpp>
 
 using namespace geode::prelude;
-
 
 class $modify(GeodeCCEGLView, CCEGLView) {
     void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
@@ -202,3 +203,5 @@ class $modify(CCKeyboardDispatcher) {
         }
     }
 };
+
+#endif

--- a/loader/src/hooks/AddExtraKeys.cpp
+++ b/loader/src/hooks/AddExtraKeys.cpp
@@ -67,21 +67,15 @@ class $modify(GeodeCCEGLView, CCEGLView) {
 
     bool isExtraKey(int code) {
         switch (code) {
-            // ;
+            case GLFW_KEY_WORLD_1:
+            case GLFW_KEY_WORLD_2:
             case GLFW_KEY_SEMICOLON:
-            // '
             case GLFW_KEY_APOSTROPHE:
-            // /
             case GLFW_KEY_SLASH:
-            // =
             case GLFW_KEY_EQUAL:
-            // [
             case GLFW_KEY_LEFT_BRACKET:
-            // backslash
             case GLFW_KEY_BACKSLASH:
-            // ]
             case GLFW_KEY_RIGHT_BRACKET:
-            // ~
             case GLFW_KEY_GRAVE_ACCENT:
                 return true;
             default:
@@ -91,30 +85,26 @@ class $modify(GeodeCCEGLView, CCEGLView) {
 
     enumKeyCodes extraKeyToKeyCode(int key) {
         switch (key) {
-            // ;
             case GLFW_KEY_SEMICOLON:
                 return enumKeyCodes::KEY_Semicolon;
-            // '
             case GLFW_KEY_APOSTROPHE:
                 return enumKeyCodes::KEY_Apostrophe;
-            // /
             case GLFW_KEY_SLASH:
                 return enumKeyCodes::KEY_Slash;
-            // =
             case GLFW_KEY_EQUAL:
                 return enumKeyCodes::KEY_OEMEqual;
-            // [
             case GLFW_KEY_LEFT_BRACKET:
                 return enumKeyCodes::KEY_LeftBracket;
-            // backslash
             case GLFW_KEY_BACKSLASH:
                 return enumKeyCodes::KEY_Backslash;
-            // ]
             case GLFW_KEY_RIGHT_BRACKET:
                 return enumKeyCodes::KEY_RightBracket;
-            // ~
             case GLFW_KEY_GRAVE_ACCENT:
                 return enumKeyCodes::KEY_GraveAccent;
+            case GLFW_KEY_WORLD_1:
+                return enumKeyCodes::KEY_World1;
+            case GLFW_KEY_WORLD_2:
+                return enumKeyCodes::KEY_World2;
             default:
                 return enumKeyCodes::KEY_Unknown;
         }
@@ -193,6 +183,10 @@ class $modify(CCKeyboardDispatcher) {
                 return "/";
             case KEY_NumEnter:
                 return "NumEnter";
+            case KEY_World1:
+                return "INTL-1";
+            case KEY_World2:
+                return "INTL-2";
             case MOUSE_4:
                 return "Mouse 4";
             case MOUSE_5:

--- a/loader/src/hooks/AddExtraKeys.cpp
+++ b/loader/src/hooks/AddExtraKeys.cpp
@@ -1,0 +1,109 @@
+#include <Geode/cocos/robtop/glfw/glfw3.h>
+#include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDispatcher.h>
+#include <Geode/cocos/text_input_node/CCIMEDispatcher.h>
+#include <Geode/modify/Modify.hpp>
+#include <Geode/modify/CCEGLView.hpp>
+
+using namespace geode::prelude;
+
+class $modify(CCEGLView) {
+    void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
+        if (!isExtraKey(key)) {
+            return CCEGLView::onGLFWKeyCallback(window, key, scancode, action, mods);
+        }
+        if (CCIMEDispatcher::sharedDispatcher()->hasDelegate()) {
+            return CCEGLView::onGLFWKeyCallback(window, key, scancode, action, mods);
+        }
+        bool down = action == 1 || action == 2;
+        bool repeat = action == 2;
+        enumKeyCodes keyCode = this->extraKeyToKeyCode(key);
+        CCKeyboardDispatcher::get()->dispatchKeyboardMSG(keyCode, down, repeat);
+    }
+
+    void onGLFWMouseCallBack(GLFWwindow* window, int button, int action, int mods) {
+        if (!isExtraMouseButton(button)) {
+            return CCEGLView::onGLFWMouseCallBack(window, button, action, mods);
+        }
+        bool down = action == 1;
+        // mouse buttons never repeat
+        bool repeat = false;
+        enumKeyCodes keyCode = this->mouseButtonToKeyCode(button);
+        CCKeyboardDispatcher::get()->dispatchKeyboardMSG(keyCode, down, repeat);
+    }
+
+    bool isExtraMouseButton(int code) {
+        return code > GLFW_MOUSE_BUTTON_3;
+    }
+
+    enumKeyCodes mouseButtonToKeyCode(int button) {
+        switch (button) {
+            case GLFW_MOUSE_BUTTON_4:
+                return enumKeyCodes::MOUSE_4;
+            case GLFW_MOUSE_BUTTON_5:
+                return enumKeyCodes::MOUSE_5;
+            case GLFW_MOUSE_BUTTON_6:
+                return enumKeyCodes::MOUSE_6;
+            case GLFW_MOUSE_BUTTON_7:
+                return enumKeyCodes::MOUSE_7;
+            case GLFW_MOUSE_BUTTON_8:
+                return enumKeyCodes::MOUSE_8; 
+            default:
+                return enumKeyCodes::KEY_Unknown;
+        }
+    }
+
+    bool isExtraKey(int code) {
+        switch (code) {
+            // ;
+            case GLFW_KEY_SEMICOLON:
+            // '
+            case GLFW_KEY_APOSTROPHE:
+            // /
+            case GLFW_KEY_SLASH:
+            // =
+            case GLFW_KEY_EQUAL:
+            // [
+            case GLFW_KEY_LEFT_BRACKET:
+            // backslash
+            case GLFW_KEY_BACKSLASH:
+            // ]
+            case GLFW_KEY_RIGHT_BRACKET:
+            // ~
+            case GLFW_KEY_GRAVE_ACCENT:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    enumKeyCodes extraKeyToKeyCode(int key) {
+        switch (key) {
+            // ;
+            case GLFW_KEY_SEMICOLON:
+                return enumKeyCodes::KEY_Semicolon;
+            // '
+            case GLFW_KEY_APOSTROPHE:
+                return enumKeyCodes::KEY_Apostrophe;
+            // /
+            case GLFW_KEY_SLASH:
+                return enumKeyCodes::KEY_Slash;
+            // =
+            case GLFW_KEY_EQUAL:
+                return enumKeyCodes::KEY_Equal;
+            // [
+            case GLFW_KEY_LEFT_BRACKET:
+                return enumKeyCodes::KEY_LeftBracket;
+            // backslash
+            case GLFW_KEY_BACKSLASH:
+                return enumKeyCodes::KEY_Backslash;
+            // ]
+            case GLFW_KEY_RIGHT_BRACKET:
+                return enumKeyCodes::KEY_RightBracket;
+            // ~
+            case GLFW_KEY_GRAVE_ACCENT:
+                return enumKeyCodes::KEY_GraveAccent;
+            default:
+                return enumKeyCodes::KEY_Unknown;
+        }
+    }
+};

--- a/loader/src/hooks/AddExtraKeys.cpp
+++ b/loader/src/hooks/AddExtraKeys.cpp
@@ -1,14 +1,21 @@
+#include <Geode/DefaultInclude.hpp>
 #include <Geode/cocos/robtop/glfw/glfw3.h>
 #include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDispatcher.h>
+#include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h>
 #include <Geode/cocos/text_input_node/CCIMEDispatcher.h>
 #include <Geode/modify/Modify.hpp>
 #include <Geode/modify/CCEGLView.hpp>
+#include <Geode/modify/CCKeyboardDispatcher.hpp>
 
 using namespace geode::prelude;
 
-class $modify(CCEGLView) {
+
+class $modify(GeodeCCEGLView, CCEGLView) {
     void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
-        if (!isExtraKey(key)) {
+        log::info("glfw key {}", key);
+        bool extraKey = isExtraKey(key);
+        bool numpad = isKeyNumpad(key);
+        if (!extraKey && !numpad) {
             return CCEGLView::onGLFWKeyCallback(window, key, scancode, action, mods);
         }
         if (CCIMEDispatcher::sharedDispatcher()->hasDelegate()) {
@@ -16,7 +23,13 @@ class $modify(CCEGLView) {
         }
         bool down = action == 1 || action == 2;
         bool repeat = action == 2;
-        enumKeyCodes keyCode = this->extraKeyToKeyCode(key);
+        enumKeyCodes keyCode = enumKeyCodes::KEY_Unknown;
+        if (extraKey) {
+            keyCode = this->extraKeyToKeyCode(key);
+        }
+        if (numpad) {
+            keyCode = this->numpadToKeyCode(key);
+        }
         CCKeyboardDispatcher::get()->dispatchKeyboardMSG(keyCode, down, repeat);
     }
 
@@ -89,7 +102,7 @@ class $modify(CCEGLView) {
                 return enumKeyCodes::KEY_Slash;
             // =
             case GLFW_KEY_EQUAL:
-                return enumKeyCodes::KEY_Equal;
+                return enumKeyCodes::KEY_OEMEqual;
             // [
             case GLFW_KEY_LEFT_BRACKET:
                 return enumKeyCodes::KEY_LeftBracket;
@@ -104,6 +117,94 @@ class $modify(CCEGLView) {
                 return enumKeyCodes::KEY_GraveAccent;
             default:
                 return enumKeyCodes::KEY_Unknown;
+        }
+    }
+
+    bool isKeyNumpad(int code) {
+        return code >= GLFW_KEY_KP_0 && code <= GLFW_KEY_KP_EQUAL;
+    }
+
+    enumKeyCodes numpadToKeyCode(int key) {
+        switch (key) {
+            case GLFW_KEY_KP_0:
+                return enumKeyCodes::KEY_NumPad0;
+            case GLFW_KEY_KP_1:
+                return enumKeyCodes::KEY_NumPad1;
+            case GLFW_KEY_KP_2:
+                return enumKeyCodes::KEY_NumPad2;
+            case GLFW_KEY_KP_3:
+                return enumKeyCodes::KEY_NumPad3;
+            case GLFW_KEY_KP_4:
+                return enumKeyCodes::KEY_NumPad4;
+            case GLFW_KEY_KP_5:
+                return enumKeyCodes::KEY_NumPad5;
+            case GLFW_KEY_KP_6:
+                return enumKeyCodes::KEY_NumPad6;
+            case GLFW_KEY_KP_7:
+                return enumKeyCodes::KEY_NumPad7;
+            case GLFW_KEY_KP_8:
+                return enumKeyCodes::KEY_NumPad8;
+            case GLFW_KEY_KP_9:
+                return enumKeyCodes::KEY_NumPad9;
+            case GLFW_KEY_KP_DECIMAL:
+                return enumKeyCodes::KEY_Decimal;
+            case GLFW_KEY_KP_DIVIDE:
+                return enumKeyCodes::KEY_Divide;
+            case GLFW_KEY_KP_MULTIPLY:
+                return enumKeyCodes::KEY_Multiply;
+            case GLFW_KEY_KP_SUBTRACT:
+                return enumKeyCodes::KEY_Subtract;
+            case GLFW_KEY_KP_ADD:
+                return enumKeyCodes::KEY_Add;
+            case GLFW_KEY_KP_ENTER:
+                return enumKeyCodes::KEY_NumEnter;
+            case GLFW_KEY_KP_EQUAL:
+                return enumKeyCodes::KEY_Equal;
+            default:
+                return enumKeyCodes::KEY_Unknown;
+        }
+    }
+};
+
+class $modify(CCKeyboardDispatcher) {
+    GEODE_FORWARD_COMPAT_DISABLE_HOOKS("CCKeyboardDispatcher new keys")
+
+    const char* keyToString(enumKeyCodes key) {
+        if (key < 0x1000) {
+            return CCKeyboardDispatcher::keyToString(key);
+        }
+
+        switch (key) {
+            case KEY_GraveAccent:
+                return "`";
+            case KEY_OEMEqual:
+                return "=";
+            case KEY_LeftBracket:
+                return "[";
+            case KEY_RightBracket:
+                return "]";
+            case KEY_Backslash:
+                return "\\";
+            case KEY_Semicolon:
+                return ";";
+            case KEY_Apostrophe:
+                return "'";
+            case KEY_Slash:
+                return "/";
+            case KEY_NumEnter:
+                return "NumEnter";
+            case MOUSE_4:
+                return "Mouse 4";
+            case MOUSE_5:
+                return "Mouse 5";
+            case MOUSE_6:
+                return "Mouse 6";
+            case MOUSE_7:
+                return "Mouse 7";
+            case MOUSE_8:
+                return "Mouse 8";
+            default:
+                return CCKeyboardDispatcher::keyToString(KEY_Unknown);
         }
     }
 };


### PR DESCRIPTION
This PR implements unused keys and mouse buttons. It does not include mouse left click, right click, scroll click.
Additionally, it remaps numpad input from their KEY_1 - KEY_0 counterparts to their actual numpad enumKeyCodes.

Added key codes are as follows

```cpp
KEY_GraveAccent = 0x1000,
KEY_OEMEqual = 0x1001,
KEY_LeftBracket = 0x1002,
KEY_RightBracket = 0x1003,
KEY_Backslash = 0x1004,
KEY_Semicolon = 0x1005,
KEY_Apostrophe = 0x1006,
KEY_Slash = 0x1007,
KEY_Equal = 0x1008,
KEY_NumEnter = 0x1009,
// Keys used by some non-US keyboard layouts
KEY_World1 = 0x100A,
KEY_World2 = 0x100B,
// Mouse buttons (excluding clicks)
MOUSE_4 = 0x1100,
MOUSE_5 = 0x1101,
MOUSE_6 = 0x1102,
MOUSE_7 = 0x1103,
MOUSE_8 = 0x1104
```

`CCKeyboardDispatcher::dispatchKeyboardMSG` will use these codes instead of -1. Additionally, I have hooked `CCKeyboardDispatcher::keyToString` for the newly created key codes.

This will remain a draft PR until I figure out how MacOS does keyboard and mouse input.