### PR TITLE
`geode::cocos::isSpriteName` and `geode::cocos::getChildBySpriteName`

### DIFF
--- a/loader/include/Geode/utils/cocos.hpp
+++ b/loader/include/Geode/utils/cocos.hpp
@@ -763,6 +763,28 @@ namespace geode::cocos {
     GEODE_DLL cocos2d::CCNode* getChildBySpriteFrameName(cocos2d::CCNode* parent, const char* name);
 
     /**
+     * Checks if a node has the given sprite name either
+     * in the sprite or in the sprite inside the button.
+     * 
+     * @param node Node to check
+     * @param name Name of the sprite to search for
+     * @returns True if the node has the given sprite name
+     */
+    GEODE_DLL bool isSpriteName(cocos2d::CCNode* node, const char* name);
+
+    /**
+     * Get the first child that has the given sprite name
+     * either in the sprite or in the sprite inside the
+     * button.
+     *
+     * @param parent Parent node to search in
+     * @param name Name of the sprite to search for
+     * @returns Child with the given sprite name, or
+     * nullptr if there is none
+     */
+    GEODE_DLL cocos2d::CCNode* getChildBySpriteName(cocos2d::CCNode* parent, const char* name);
+
+    /**
      * Checks if a given file exists in CCFileUtils
      * search paths.
      * @param filename File to check

--- a/loader/src/utils/cocos.cpp
+++ b/loader/src/utils/cocos.cpp
@@ -372,6 +372,37 @@ CCNode* geode::cocos::getChildBySpriteFrameName(CCNode* parent, const char* name
     return nullptr;
 }
 
+bool geode::cocos::isSpriteName(CCNode* node, const char* name) {
+    if (!node) return false;
+
+    auto texture = CCTextureCache::sharedTextureCache()->textureForKey(name);
+    if (!texture) return false;
+
+    if (auto* spr = typeinfo_cast<CCSprite*>(node)) {
+        if (spr->getTexture() == texture) {
+            return true;
+        }
+    }
+    else if (auto* btn = typeinfo_cast<CCMenuItemSprite*>(node)) {
+        auto* img = btn->getNormalImage();
+        if (auto* spr = typeinfo_cast<CCSprite*>(img)) {
+            if (spr->getTexture() == texture) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+CCNode* geode::cocos::getChildBySpriteName(CCNode* parent, const char* name) {
+    for (auto child : CCArrayExt<CCNode*>(parent->getChildren())) {
+        if (::isSpriteName(static_cast<CCNode*>(child), name)) {
+            return child;
+        }
+    }
+    return nullptr;
+}
+
 CCRect geode::cocos::calculateNodeCoverage(std::vector<CCNode*> const& nodes) {
     CCRect coverage;
     for (auto child : nodes) {


### PR DESCRIPTION
Tentative function names. Suggestions are very much welcome.

This is in the case of a sprite having image that is not part of a texture frame.