### PR TITLE
Make getGameVersion public

### DIFF
--- a/loader/include/Geode/loader/Loader.hpp
+++ b/loader/include/Geode/loader/Loader.hpp
@@ -140,6 +140,12 @@ namespace geode {
 
         void queueInMainThread(ScheduledFunction func);
 
+        /**
+         * Returns the current game version.
+         * @return The game version
+         */
+        std::string getGameVersion();
+
         friend class LoaderImpl;
 
         friend Mod* takeNextLoaderMod();

--- a/loader/src/loader/Loader.cpp
+++ b/loader/src/loader/Loader.cpp
@@ -73,6 +73,10 @@ void Loader::queueInMainThread(ScheduledFunction func) {
     return m_impl->queueInMainThread(std::move(func));
 }
 
+std::string Loader::getGameVersion() {
+    return m_impl->getGameVersion();
+}
+
 Mod* Loader::takeNextMod() {
     return m_impl->takeNextMod();
 }


### PR DESCRIPTION
Can be useful to some mods that have `"gd": "*"` in their `mod.json`