### PR TITLE
show info key from mod.json in geode::openIssueReportPopup

### DIFF
--- a/loader/src/ui/internal/GeodeUI.cpp
+++ b/loader/src/ui/internal/GeodeUI.cpp
@@ -17,7 +17,7 @@ void geode::openIssueReportPopup(Mod* mod) {
         auto info = issues.value().info;
         MDPopup::create(
             "Issue Report",
-                info
+                info,
             "OK", "Open Folder",
             [mod](bool btn2) {
                 if (btn2) {

--- a/loader/src/ui/internal/GeodeUI.cpp
+++ b/loader/src/ui/internal/GeodeUI.cpp
@@ -17,7 +17,10 @@ void geode::openIssueReportPopup(Mod* mod) {
         auto info = issues.value().info;
         MDPopup::create(
             "Issue Report",
-                info,
+                info
+                "\n\n"
+                "If the issue is related to a <cy>crash</c>, <cb>please include the latest crash log(s)</c> from `"
+                dirs::getCrashlogsDir().string() + "`",
             "OK", "Open Folder",
             [mod](bool btn2) {
                 if (btn2) {

--- a/loader/src/ui/internal/GeodeUI.cpp
+++ b/loader/src/ui/internal/GeodeUI.cpp
@@ -17,10 +17,7 @@ void geode::openIssueReportPopup(Mod* mod) {
         auto info = issues.value().info;
         MDPopup::create(
             "Issue Report",
-                info
-                "\n\n"
-                "If the issue is related to a <cy>crash</c>, <cb>please include the latest crash log(s)</c> from `"
-                dirs::getCrashlogsDir().string() + "`",
+                info + "\n\n" + "If the issue is related to a <cy>crash</c>, <cb>please include the latest crash log(s)</c> from `" + dirs::getCrashlogsDir().string() + "`",
             "OK", "Open Folder",
             [mod](bool btn2) {
                 if (btn2) {

--- a/loader/src/ui/internal/GeodeUI.cpp
+++ b/loader/src/ui/internal/GeodeUI.cpp
@@ -13,13 +13,11 @@ void geode::openModsList() {
 }
 
 void geode::openIssueReportPopup(Mod* mod) {
-    if (mod->getMetadata().getIssues()) {
+    if (auto issues = mod->getMetadata().getIssues()) {
+        auto info = issues.value().info;
         MDPopup::create(
             "Issue Report",
-                "Please report the issue to the mod that caused the crash.\n"
-                "If your issue relates to a <cr>game crash</c>, <cb>please include</c> the "
-                "latest crash log(s) from `" +
-                dirs::getCrashlogsDir().string() + "`",
+                info
             "OK", "Open Folder",
             [mod](bool btn2) {
                 if (btn2) {


### PR DESCRIPTION
changes the `geode::openIssueReportPopup` function to show the contents of the `info` key from `mod.json` instead of a hardcoded message