### PR TITLE
Add disable-auto-mod-updates option

### DIFF
--- a/loader/resources/mod.json.in
+++ b/loader/resources/mod.json.in
@@ -92,6 +92,12 @@
             "default": true,
             "name": "Enable Geode-Themed Colors",
             "description": "When enabled, the Geode menu has a <ca>Geode-themed color scheme</c>. <cy>This does not affect any other menus!</c>"
+        },
+        "disable-auto-mod-updates": {
+            "type": "bool",
+            "default": false,
+            "name": "Disable auto mod updates",
+            "description": "When enabled, Geode won't check for mod updates at game startup, which is useful for slow connections or conserving mobile data."
         }
     },
     "issues": {


### PR DESCRIPTION

Apart from the option, I've added a notification for when auto update is disabled, it displays only once when the game starts. This is mainly to avoid people forgetting they enabled the option and thinking that geode isn't checking for updates because of a bug or similar.

![image.](https://github.com/geode-sdk/geode/assets/54410739/f13211b2-5d70-41a3-a9c9-79cbc7edd4f2)

Also makes index updates only happen at startup insetad of everytime MenuLayer::init runs

diff is dirty but the only additions are [this](https://github.com/iAndyHD3/geode/blob/d3b6e397048e382a0c785f56a90b12e073265c9e/loader/src/hooks/MenuLayer.cpp#L165-L166) and [this](https://github.com/iAndyHD3/geode/blob/d3b6e397048e382a0c785f56a90b12e073265c9e/loader/src/hooks/MenuLayer.cpp#L199-L204)