### PR TITLE
Fixes for TextInput

### DIFF
--- a/loader/src/ui/nodes/TextInput.cpp
+++ b/loader/src/ui/nodes/TextInput.cpp
@@ -70,7 +70,7 @@ bool TextInput::init(float width, std::string const& placeholder, std::string co
     m_bgSprite->setContentSize({ width * 2, HEIGHT * 2 });
     this->addChildAtPosition(m_bgSprite, Anchor::Center);
 
-    m_input = CCTextInputNode::create(width, HEIGHT, placeholder.c_str(), 24, font.c_str());
+    m_input = CCTextInputNode::create(width - 10.f, HEIGHT, placeholder.c_str(), 24, font.c_str());
     m_input->setLabelPlaceholderColor({ 150, 150, 150 });
     m_input->setLabelPlaceholderScale(.5f);
     m_input->setMaxLabelScale(.6f);
@@ -132,9 +132,12 @@ void TextInput::setPasswordMode(bool enable) {
     m_input->refreshLabel();
 }
 void TextInput::setWidth(float width) {
-    m_input->m_maxLabelWidth = width;
-    m_input->setContentWidth(width * 2);
+    this->setContentWidth(width);
+    m_input->m_maxLabelWidth = width - 10.f;
+    m_input->setContentWidth(width);
     m_bgSprite->setContentWidth(width * 2);
+    m_input->setPositionX(width / 2.f);
+    m_bgSprite->setPositionX(width / 2.f);
 }
 void TextInput::setDelegate(TextInputDelegate* delegate, std::optional<int> tag) {
     m_input->m_delegate = delegate;


### PR DESCRIPTION
## fixes padding for TextInput
before this PR, when using textalign center there was no padding for text that reached the sides of the input box:
![image](https://github.com/geode-sdk/geode/assets/44374434/a6d47460-e8fa-4260-9be1-80bb519d40a2)

and when using textalign left there was padding on the left but on the right it overflowed.
![image](https://github.com/geode-sdk/geode/assets/44374434/8bf64fde-306e-425d-8a33-d7a2556e5fe9)

this PR fixes both cases to this:
![image](https://github.com/geode-sdk/geode/assets/44374434/027e344a-c27e-4c0b-be0f-43bd473748ae)

## fixes setWidth
before this PR, setWidth doesn't set the width of the TextInput node. So if you set the width to a number smaller than the original width, it'd look like this:
![image](https://github.com/geode-sdk/geode/assets/44374434/9bda6baf-9536-4668-9ffa-b36ce01f1b88)

and if you set the width to a number larger than the original width:
![image](https://github.com/geode-sdk/geode/assets/44374434/8b50b396-a3e5-48d6-a2a4-b84cef025d97)

this PR fixes that