### PR TITLE
Added IDs to web request to prevent incompatibilities between web mods

### DIFF
--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -112,8 +112,9 @@ namespace geode::utils::web {
     private:
         class Impl;
 
+        static size_t m_idCounter;
         std::shared_ptr<Impl> m_impl;
-
+        const size_t m_id;
     public:
         WebRequest();
         ~WebRequest();
@@ -252,6 +253,13 @@ namespace geode::utils::web {
          * @return WebRequest&
          */
         WebRequest& bodyJSON(matjson::Value const& json);
+
+        /**
+         * Gets the unique request ID
+         *
+         * @return size_t
+         */
+        size_t getID() const;
 
 
         /**

--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -112,7 +112,7 @@ namespace geode::utils::web {
     private:
         class Impl;
 
-        static size_t m_idCounter;
+        static std::atomic_size_t s_idCounter;
         std::shared_ptr<Impl> m_impl;
         const size_t m_id;
     public:

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -212,7 +212,9 @@ public:
     }
 };
 
-WebRequest::WebRequest() : m_impl(std::make_shared<Impl>()) {}
+size_t WebRequest::m_idCounter = 0;
+
+WebRequest::WebRequest() : m_impl(std::make_shared<Impl>()), m_id(WebRequest::m_idCounter++) {}
 WebRequest::~WebRequest() {}
 
 // Encodes a url param
@@ -582,6 +584,10 @@ WebRequest& WebRequest::bodyJSON(matjson::Value const& json) {
     std::string str = json.dump(matjson::NO_INDENTATION);
     m_impl->m_body = ByteVector { str.begin(), str.end() };
     return *this;
+}
+
+size_t WebRequest::getID() const {
+    return m_id;
 }
 
 std::string WebRequest::getMethod() const {

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -212,9 +212,9 @@ public:
     }
 };
 
-size_t WebRequest::m_idCounter = 0;
+std::atomic_size_t WebRequest::s_idCounter = 0;
 
-WebRequest::WebRequest() : m_impl(std::make_shared<Impl>()), m_id(WebRequest::m_idCounter++) {}
+WebRequest::WebRequest() : m_impl(std::make_shared<Impl>()), m_id(WebRequest::s_idCounter++) {}
 WebRequest::~WebRequest() {}
 
 // Encodes a url param


### PR DESCRIPTION
Currently web mods need to check for pointers to prevent hook recursion. But to prevent the request from being thrown out you also need to copy it. This makes it so there can never be 2 web mods active at the same time.