### PR TITLE
Fixing current working directory on startup

### DIFF
--- a/loader/src/platform/windows/main.cpp
+++ b/loader/src/platform/windows/main.cpp
@@ -151,7 +151,6 @@ static void fixCWD() {
             break;
         }
     }
-    console::messageBox("Geode", fmt::format("Hello from gdMainHook!\Setting CWD: {}", cwd));
     SetCurrentDirectoryA(cwd);
 }
 

--- a/loader/src/platform/windows/main.cpp
+++ b/loader/src/platform/windows/main.cpp
@@ -138,10 +138,29 @@ void* mainTrampolineAddr;
 #include "gdTimestampMap.hpp"
 unsigned int gdTimestamp = 0;
 
+// In case the game is launched from a different directory through command line
+// this function will set the current working directory to the game's directory
+// to avoid the game crashing due to not being able to find the resources
+static void fixCWD() {
+    char cwd[1024];
+    DWORD size = GetModuleFileNameA(NULL, cwd, sizeof(cwd));
+    if (size == sizeof(cwd)) return;
+    for (int i = size - 1; i >= 0; i--) {
+        if (cwd[i] == '\\') {
+            cwd[i] = '\0';
+            break;
+        }
+    }
+    console::messageBox("Geode", fmt::format("Hello from gdMainHook!\Setting CWD: {}", cwd));
+    SetCurrentDirectoryA(cwd);
+}
+
 int WINAPI gdMainHook(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow) {
     // MessageBoxA(NULL, "Hello from gdMainHook!", "Hi", 0);
 
     updateGeode();
+
+    fixCWD();
 
     if (versionToTimestamp(GEODE_STR(GEODE_GD_VERSION)) > gdTimestamp) {
         console::messageBox(

--- a/loader/src/platform/windows/main.cpp
+++ b/loader/src/platform/windows/main.cpp
@@ -141,22 +141,13 @@ unsigned int gdTimestamp = 0;
 // In case the game is launched from a different directory through command line
 // this function will set the current working directory to the game's directory
 // to avoid the game crashing due to not being able to find the resources
-static void fixCWD() {
+void fixCurrentWorkingDirectory() {
     std::array<WCHAR, MAX_PATH> cwd;
     
-    DWORD size = GetModuleFileNameW(NULL, cwd.data(), cwd.size());
+    auto size = GetModuleFileNameW(nullptr, cwd.data(), cwd.size());
     if (size == cwd.size()) return;
-    
-    int i;
-    for (i = (int)size - 1; i >= 0; i--) {
-        if (cwd[i] == '\\') {
-            cwd[i] = 0;
-            break;
-        }
-    }
-    if (i < 0) return;
 
-    SetCurrentDirectoryW(cwd.data());
+    SetCurrentDirectoryW(std::filesystem::path(cwd.data()).parent_path().wstring().c_str());
 }
 
 int WINAPI gdMainHook(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow) {
@@ -164,7 +155,7 @@ int WINAPI gdMainHook(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmd
 
     updateGeode();
 
-    fixCWD();
+    fixCurrentWorkingDirectory();
 
     if (versionToTimestamp(GEODE_STR(GEODE_GD_VERSION)) > gdTimestamp) {
         console::messageBox(

--- a/loader/src/platform/windows/main.cpp
+++ b/loader/src/platform/windows/main.cpp
@@ -142,16 +142,21 @@ unsigned int gdTimestamp = 0;
 // this function will set the current working directory to the game's directory
 // to avoid the game crashing due to not being able to find the resources
 static void fixCWD() {
-    WCHAR cwd[MAX_PATH];
-    DWORD size = GetModuleFileNameW(NULL, cwd, sizeof(cwd));
-    if (size == sizeof(cwd)) return;
-    for (int i = size - 1; i >= 0; i--) {
+    std::array<WCHAR, MAX_PATH> cwd;
+    
+    DWORD size = GetModuleFileNameW(NULL, cwd.data(), cwd.size());
+    if (size == cwd.size()) return;
+    
+    int i;
+    for (i = (int)size - 1; i >= 0; i--) {
         if (cwd[i] == '\\') {
-            cwd[i] = '\0';
+            cwd[i] = 0;
             break;
         }
     }
-    SetCurrentDirectoryW(cwd);
+    if (i < 0) return;
+
+    SetCurrentDirectoryW(cwd.data());
 }
 
 int WINAPI gdMainHook(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow) {

--- a/loader/src/platform/windows/main.cpp
+++ b/loader/src/platform/windows/main.cpp
@@ -142,8 +142,8 @@ unsigned int gdTimestamp = 0;
 // this function will set the current working directory to the game's directory
 // to avoid the game crashing due to not being able to find the resources
 static void fixCWD() {
-    char cwd[1024];
-    DWORD size = GetModuleFileNameA(NULL, cwd, sizeof(cwd));
+    WCHAR cwd[MAX_PATH];
+    DWORD size = GetModuleFileNameW(NULL, cwd, sizeof(cwd));
     if (size == sizeof(cwd)) return;
     for (int i = size - 1; i >= 0; i--) {
         if (cwd[i] == '\\') {
@@ -151,7 +151,7 @@ static void fixCWD() {
             break;
         }
     }
-    SetCurrentDirectoryA(cwd);
+    SetCurrentDirectoryW(cwd);
 }
 
 int WINAPI gdMainHook(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nCmdShow) {


### PR DESCRIPTION
The game crashes if launched from command prompt from a directory other than the game's directory.
This should fix the CWD back to the GD directory.

I need this so I can easily run GD from a batch script after compiling my mod.