### PR TITLE
fix `CCArrayExt::pop_back()` `ret` variable not being a pointer

### DIFF
--- a/loader/include/Geode/utils/cocos.hpp
+++ b/loader/include/Geode/utils/cocos.hpp
@@ -1080,7 +1080,7 @@ namespace geode::cocos {
         }
 
         T* pop_back() {
-            T ret = m_arr->lastObject();
+            T* ret = static_cast<T*>(m_arr->lastObject());
             m_arr->removeLastObject();
             return ret;
         }


### PR DESCRIPTION
The old code works fine if you don't use the return value but just in case someone does uses it (me)
![Screenshot_20241102_230110_Termux](https://github.com/user-attachments/assets/d8ed2520-b9c5-4c03-a468-14a94a36824e)
