### PR TITLE
Fix mod downloads not using the metadata version to download

### DIFF
--- a/loader/src/server/Server.cpp
+++ b/loader/src/server/Server.cpp
@@ -8,6 +8,7 @@
 #include <fmt/chrono.h>
 #include <loader/LoaderImpl.hpp>
 #include "../internal/about.hpp"
+#include "Geode/loader/Loader.hpp"
 
 using namespace server;
 
@@ -647,7 +648,7 @@ ServerRequest<ServerModVersion> server::getModVersion(std::string const& id, Mod
         },
     }, version);
 
-    return req.get(formatServerURL("/mods/{}/versions/{}", id, versionURL)).map(
+    return req.get(formatServerURL("/mods/{}/versions/{}?gd={}", id, versionURL, Loader::get()->getGameVersion())).map(
         [](web::WebResponse* response) -> Result<ServerModVersion, ServerError> {
             if (response->ok()) {
                 // Parse payload

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -8,6 +8,7 @@
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/loader/Loader.hpp>
+#include "server/DownloadManager.hpp"
 #include "ui/mods/GeodeStyle.hpp"
 #include "ui/mods/popups/ModPopup.hpp"
 #include "ui/mods/popups/DevPopup.hpp"
@@ -631,18 +632,7 @@ void ModItem::onEnable(CCObject*) {
     UpdateModListStateEvent(UpdateModState(m_source.getID())).post();
 }
 void ModItem::onInstall(CCObject*) {
-    if (auto updates = m_source.hasUpdates()) {
-        if (updates->replacement.has_value()) {
-            server::ModDownloadManager::get()->startDownload(
-                updates->replacement->id,
-                updates->replacement->version,
-                std::nullopt,
-                m_source.getID()
-            );
-            return;
-        }
-    }
-    server::ModDownloadManager::get()->startDownload(m_source.getID(), std::nullopt);
+    m_source.startInstall();
 }
 void ModItem::onDevelopers(CCObject*) {
     DevListPopup::create(m_source)->show();

--- a/loader/src/ui/mods/popups/ModPopup.cpp
+++ b/loader/src/ui/mods/popups/ModPopup.cpp
@@ -7,11 +7,13 @@
 #include <Geode/loader/ModSettingsManager.hpp>
 #include <Geode/ui/GeodeUI.hpp>
 #include <Geode/utils/ColorProvider.hpp>
+#include <optional>
 #include "ConfirmUninstallPopup.hpp"
 #include "../settings/ModSettingsPopup.hpp"
 #include "../../../internal/about.hpp"
 #include "../../GeodeUIEvent.hpp"
 #include "../popups/ModtoberPopup.hpp"
+#include "server/DownloadManager.hpp"
 
 class FetchTextArea : public CCNode {
 public:
@@ -1047,7 +1049,9 @@ void ModPopup::onInstall(CCObject*) {
             return;
         }
     }
-    server::ModDownloadManager::get()->startDownload(m_source.getID(), std::nullopt);
+
+    m_source.startInstall();
+
     this->onClose(nullptr);
 }
 

--- a/loader/src/ui/mods/sources/ModSource.cpp
+++ b/loader/src/ui/mods/sources/ModSource.cpp
@@ -240,3 +240,27 @@ server::ServerRequest<std::optional<server::ServerModUpdate>> ModSource::checkUp
         },
     }, m_value);
 }
+void ModSource::startInstall() {
+    if (auto updates = this->hasUpdates()) {
+        if (updates->replacement.has_value()) {
+            server::ModDownloadManager::get()->startDownload(
+                updates->replacement->id,
+                updates->replacement->version,
+                std::nullopt,
+                this->getID()
+            );
+        } else {
+            server::ModDownloadManager::get()->startDownload(
+                this->getID(),
+                updates->version
+            );
+        }
+    } else {
+        server::ModDownloadManager::get()->startDownload(
+            this->getID(),
+            this->asServer()
+                ? std::optional{this->asServer()->latestVersion().getVersion()}
+                : std::nullopt
+        );
+    }
+}

--- a/loader/src/ui/mods/sources/ModSource.hpp
+++ b/loader/src/ui/mods/sources/ModSource.hpp
@@ -49,4 +49,5 @@ public:
     server::ServerRequest<std::optional<std::string>> fetchChangelog() const;
     server::ServerRequest<std::unordered_set<std::string>> fetchValidTags() const;
     server::ServerRequest<std::optional<server::ServerModUpdate>> checkUpdates();
+    void startInstall();
 };


### PR DESCRIPTION
Currently, mods fetch mod metadata from /v1/mods/{id}/latest version, if no version is passed in ModDownloadManager::startDownload(). 

At the same time, this request doesn't include the current GD version as a query param, so it can (and will) fetch mods from incompatible game versions.

Fix is adding this query param as a failsafe and using the mod metadata to download, wherever possible.

We also have to backport this fix to v3 quite fast