### PR TITLE
Updated the headers map in WebRequest and WebResponse to accept multiple headers with the same name

### DIFF
--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -83,6 +83,14 @@ namespace geode::utils::web {
 
         std::vector<std::string> headers() const;
         std::optional<std::string> header(std::string_view name) const;
+
+        /**
+         * Retrieves a list of all headers from the response with a given name - there can be
+         * multiple headers with the same name, such as Set-Cookie, with each cookie in a separate
+         * header
+         * @param name name of the header
+         * @return std::optional<std::vector<std::string>>
+         */
         std::optional<std::vector<std::string>> headersWithName(std::string_view name) const;
     };
 
@@ -287,7 +295,7 @@ namespace geode::utils::web {
         /**
          * Gets the request headers
          *
-         * @return std::unordered_map<std::string, std::string>
+         * @return std::unordered_map<std::string, std::vector<std::string>>
          */
         std::unordered_map<std::string, std::vector<std::string>> getHeaders() const;
 

--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -91,7 +91,7 @@ namespace geode::utils::web {
          * @param name name of the header
          * @return std::optional<std::vector<std::string>>
          */
-        std::optional<std::vector<std::string>> headersWithName(std::string_view name) const;
+        std::optional<std::vector<std::string>> getAllHeadersNamed(std::string_view name) const;
     };
 
     class GEODE_DLL WebProgress final {

--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -82,7 +82,7 @@ namespace geode::utils::web {
         Result<> into(std::filesystem::path const& path) const;
 
         std::vector<std::string> headers() const;
-        std::optional<std::string> header(std::string_view name) const;
+        std::optional<std::string> header(std::string_view name, int index = 0) const;
     };
 
     class GEODE_DLL WebProgress final {
@@ -288,7 +288,7 @@ namespace geode::utils::web {
          *
          * @return std::unordered_map<std::string, std::string>
          */
-        std::unordered_map<std::string, std::string> getHeaders() const;
+        std::unordered_map<std::string, std::vector<std::string>> getHeaders() const;
 
         /**
          * Gets the parameters inside the URL

--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -82,7 +82,8 @@ namespace geode::utils::web {
         Result<> into(std::filesystem::path const& path) const;
 
         std::vector<std::string> headers() const;
-        std::optional<std::string> header(std::string_view name, int index = 0) const;
+        std::optional<std::string> header(std::string_view name) const;
+        std::optional<std::vector<std::string>> headersWithName(std::string_view name) const;
     };
 
     class GEODE_DLL WebProgress final {

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -152,7 +152,7 @@ std::optional<std::string> WebResponse::header(std::string_view name) const {
     return std::nullopt;
 }
 
-std::optional<std::vector<std::string>> WebResponse::headersWithName(std::string_view name) const {
+std::optional<std::vector<std::string>> WebResponse::getAllHeadersNamed(std::string_view name) const {
     if (auto str = std::string(name); m_impl->m_headers.contains(str)) {
         return m_impl->m_headers.at(str);
     }

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -145,14 +145,16 @@ std::vector<std::string> WebResponse::headers() const {
     return map::keys(m_impl->m_headers);
 }
 
-std::optional<std::string> WebResponse::header(std::string_view name, int index) const {
-    auto str = std::string(name);
-    if (m_impl->m_headers.contains(str)) {
-        const auto headersWithName = m_impl->m_headers.at(str);
-        if (headersWithName.size() > index) {
-            return headersWithName.at(index);
-        }
-        return std::nullopt;
+std::optional<std::string> WebResponse::header(std::string_view name) const {
+    if (auto str = std::string(name); m_impl->m_headers.contains(str)) {
+        return m_impl->m_headers.at(str).at(0);
+    }
+    return std::nullopt;
+}
+
+std::optional<std::vector<std::string>> WebResponse::headersWithName(std::string_view name) const {
+    if (auto str = std::string(name); m_impl->m_headers.contains(str)) {
+        return m_impl->m_headers.at(str);
     }
     return std::nullopt;
 }

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -418,9 +418,7 @@ WebTask WebRequest::send(std::string_view method, std::string_view url) {
                 if (headers.contains(key)) {
                     headers.at(key).push_back(value);
                 } else {
-                    std::vector<std::string> headerValues;
-                    headerValues.push_back(value);
-                    headers.insert_or_assign(key, headerValues);
+                    headers.insert_or_assign(key, std::vector{value});
                 }
             }
             return size * nitems;
@@ -529,9 +527,7 @@ WebRequest& WebRequest::header(std::string_view name, std::string_view value) {
     if (m_impl->m_headers.contains(strName)) {
         m_impl->m_headers.at(strName).push_back(strValue);
     } else {
-        std::vector<std::string> headerValues;
-        headerValues.push_back(strValue);
-        m_impl->m_headers.insert_or_assign(strName, headerValues);
+        m_impl->m_headers.insert_or_assign(strName, std::vector{strValue});
     }
 
     return *this;


### PR DESCRIPTION
Because there can be multiple headers with the same name, for example Set-Cookie (which was the main motivation for this change)
Also it's probably terrible idk (although the game didn't explode when I tried to use it and it actually worked)