### PR TITLE
fix 1 (one) misspelling in the End User License Agreement (EULA)

### DIFF
--- a/EULA
+++ b/EULA
@@ -16,7 +16,7 @@ The End User is someone who is using Geode and Geode-based modifications. This i
 
 A Modder is someone who is using Geode and its functions in order to develope their own extensions for Geometry Dash.
 
-Geometry Dash is a game by RobTop Games. If you're using Geode, you probably know what it is. If you're an actual laywer or something alike looking at this text document, why? How did we end up in this situation? Can you let us off the hook if we just give you some cute photos of catgirls?
+Geometry Dash is a game by RobTop Games. If you're using Geode, you probably know what it is. If you're an actual lawyer or something alike looking at this text document, why? How did we end up in this situation? Can you let us off the hook if we just give you some cute photos of catgirls?
 
 ============================================
 1.1. Your rights as an End User


### PR DESCRIPTION
Please ignore the fact I misspelled "misspelling" in the commit that fixes the misspelling contained inside of the Geode SDK End User License Agreement. 