### PR TITLE
Log levels

### DIFF
--- a/loader/resources/mod.json.in
+++ b/loader/resources/mod.json.in
@@ -117,7 +117,7 @@
         },
         "file-log-level": {
             "type": "string",
-            "default": "warn",
+            "default": "info",
             "name": "File Log Level",
             "description": "Sets the log level for the <cb>log files</c>.",
             "one-of": ["debug", "info", "warn", "error"]

--- a/loader/resources/mod.json.in
+++ b/loader/resources/mod.json.in
@@ -107,6 +107,21 @@
             "platforms": ["win", "mac"],
             "requires-restart": true
         },
+        "console-log-level": {
+            "type": "string",
+            "default": "info",
+            "name": "Console Log Level",
+            "description": "Sets the log level for the <cb>platform console</c>.",
+            "platforms": ["win", "mac"],
+            "one-of": ["debug", "info", "warn", "error"]
+        },
+        "file-log-level": {
+            "type": "string",
+            "default": "warn",
+            "name": "File Log Level",
+            "description": "Sets the log level for the <cb>log files</c>.",
+            "one-of": ["debug", "info", "warn", "error"]
+        },
         "server-cache-size-limit": {
             "type": "int",
             "default": 20,

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -108,7 +108,6 @@ bool safeModeCheck() {
 int geodeEntry(void* platformData) {
     thread::setName("Main");
 
-    log::Logger::get()->setup();
     console::setup();
     if (LoaderImpl::get()->isForwardCompatMode()) {
         console::openIfClosed();
@@ -151,6 +150,10 @@ int geodeEntry(void* platformData) {
             return 1;
         }
     }
+
+    // Setup logger here so that internal mod is setup and we can read log level
+    // Logging before this point does store the log, and everything gets logged in this setup call
+    log::Logger::get()->setup();
 
     tryShowForwardCompat();
 

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -80,28 +80,28 @@ Result<> Loader::Impl::setup() {
     }
 
     if (this->supportsLaunchArguments()) {
-        log::debug("Loading launch arguments");
+        log::info("Loading launch arguments");
         log::NestScope nest;
         this->initLaunchArguments();
     }
 
     // on some platforms, using the crash handler overrides more convenient native handlers
     if (!this->getLaunchFlag("disable-crash-handler")) {
-        log::debug("Setting up crash handler");
+        log::info("Setting up crash handler");
         log::NestScope nest;
         if (!crashlog::setupPlatformHandler()) {
             log::debug("Failed to set up crash handler");
         }
     } else {
-        log::debug("Crash handler setup skipped");
+        log::info("Crash handler setup skipped");
     }
 
-    log::debug("Loading hooks");
+    log::info("Loading hooks");
     if (log::NestScope nest; !this->loadHooks()) {
         return Err("There were errors loading some hooks, see console for details");
     }
 
-    log::debug("Setting up directories");
+    log::info("Setting up directories");
     {
         log::NestScope nest;
         this->createDirectories();
@@ -112,6 +112,7 @@ Result<> Loader::Impl::setup() {
     // this function is already on the gd thread, so this should be fine
     ModStateEvent(Mod::get(), ModEventType::Loaded).post();
 
+    log::info("Refreshing mod graph");
     this->refreshModGraph();
 
     m_isSetup = true;
@@ -405,18 +406,18 @@ void Loader::Impl::loadModGraph(Mod* node, bool early) {
     }
     
     if (node->hasUnresolvedDependencies()) {
-        log::debug("{} {} has unresolved dependencies", node->getID(), node->getVersion());
+        log::warn("{} {} has unresolved dependencies", node->getID(), node->getVersion());
         return;
     }
     if (node->hasUnresolvedIncompatibilities()) {
-        log::debug("{} {} has unresolved incompatibilities", node->getID(), node->getVersion());
+        log::warn("{} {} has unresolved incompatibilities", node->getID(), node->getVersion());
         return;
     }
 
     log::NestScope nest;
 
     if (node->isEnabled()) {
-        log::warn("Mod {} already loaded, this should never happen", node->getID());
+        log::error("Mod {} already loaded, this should never happen", node->getID());
         return;
     }
 
@@ -426,16 +427,14 @@ void Loader::Impl::loadModGraph(Mod* node, bool early) {
     m_lateRefreshedModCount += early ? 0 : 1;
 
     auto unzipFunction = [this, node]() {
-        log::debug("Unzip");
-        log::NestScope nest;
+        log::debug("Unzipping .geode file");
         auto res = node->m_impl->unzipGeodeFile(node->getMetadata());
         return res;
     };
 
     auto loadFunction = [this, node, early]() {
         if (node->shouldLoad()) {
-            log::debug("Load");
-            log::NestScope nest;
+            log::debug("Loading binary");
             auto res = node->m_impl->loadBinary();
             if (!res) {
                 this->addProblem({
@@ -513,7 +512,7 @@ void Loader::Impl::findProblems() {
             continue;
         }
         if (mod->targetsOutdatedVersion()) {
-            log::debug("{} is outdated", id);
+            log::warn("{} is outdated", id);
             continue;
         }
         log::debug("{}", id);
@@ -536,7 +535,7 @@ void Loader::Impl::findProblems() {
                         log::info("{} suggests {} {}", id, dep.id, dep.version);
                     }
                     else {
-                        log::info("{} suggests {} {}, but that suggestion was dismissed", id, dep.id, dep.version);
+                        log::debug("{} suggests {} {}, but that suggestion was dismissed", id, dep.id, dep.version);
                     }
                     break;
                 case ModMetadata::Dependency::Importance::Recommended:
@@ -546,10 +545,10 @@ void Loader::Impl::findProblems() {
                             mod,
                             fmt::format("{} {}", dep.id, dep.version.toString())
                         });
-                        log::warn("{} recommends {} {}", id, dep.id, dep.version);
+                        log::info("{} recommends {} {}", id, dep.id, dep.version);
                     }
                     else {
-                        log::warn("{} recommends {} {}, but that suggestion was dismissed", id, dep.id, dep.version);
+                        log::debug("{} recommends {} {}, but that suggestion was dismissed", id, dep.id, dep.version);
                     }
                     break;
                 case ModMetadata::Dependency::Importance::Required:
@@ -648,7 +647,6 @@ void Loader::Impl::findProblems() {
 }
 
 void Loader::Impl::refreshModGraph() {
-    log::info("Refreshing mod graph");
     log::NestScope nest;
 
     if (m_isSetup) {
@@ -661,7 +659,7 @@ void Loader::Impl::refreshModGraph() {
     m_problems.clear();
 
     m_loadingState = LoadingState::Queue;
-    log::debug("Queueing mods");
+    log::info("Queueing mods");
     std::vector<ModMetadata> modQueue;
     {
         log::NestScope nest;
@@ -669,7 +667,7 @@ void Loader::Impl::refreshModGraph() {
     }
 
     m_loadingState = LoadingState::List;
-    log::debug("Populating mod list");
+    log::info("Populating mod list");
     {
         log::NestScope nest;
         this->populateModList(modQueue);
@@ -677,36 +675,38 @@ void Loader::Impl::refreshModGraph() {
     }
 
     m_loadingState = LoadingState::Graph;
-    log::debug("Building mod graph");
+    log::info("Building mod graph");
     {
         log::NestScope nest;
         this->buildModGraph();
     }
 
-    log::debug("Ordering mod stack");
+    log::info("Ordering mod stack");
     {
         log::NestScope nest;
         this->orderModStack();
     }
 
     m_loadingState = LoadingState::EarlyMods;
-    log::debug("Loading early mods");
+    log::info("Loading early mods");
     {
         log::NestScope nest;
         while (!m_modsToLoad.empty() && m_modsToLoad.front()->needsEarlyLoad()) {
             auto mod = m_modsToLoad.front();
             m_modsToLoad.pop_front();
+            log::info("Loading mod {} {}", mod->getID(), mod->getVersion());
             this->loadModGraph(mod, true);
         }
     }
 
     auto end = std::chrono::high_resolution_clock::now();
     auto time = std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
-    log::info("Took {}s. Continuing next frame...", static_cast<float>(time) / 1000.f);
+    log::debug("Took {}s. Continuing next frame...", static_cast<float>(time) / 1000.f);
 
     m_loadingState = LoadingState::Mods;
 
     queueInMainThread([this]() {
+        log::info("Loading non-early mods");
         this->continueRefreshModGraph();
     });
 }
@@ -769,10 +769,10 @@ void Loader::Impl::continueRefreshModGraph() {
     if  (m_lateRefreshedModCount > 0) {
         auto end = std::chrono::high_resolution_clock::now();
         auto time = std::chrono::duration_cast<std::chrono::milliseconds>(end - m_timerBegin).count();
-        log::info("Took {}s", static_cast<float>(time) / 1000.f);
+        log::debug("Took {}s", static_cast<float>(time) / 1000.f);
     }
 
-    log::info("Continuing mod graph refresh...");
+    log::debug("Continuing mod graph refresh...");
     log::NestScope nest;
 
     m_timerBegin = std::chrono::high_resolution_clock::now();
@@ -782,14 +782,14 @@ void Loader::Impl::continueRefreshModGraph() {
             if (!m_modsToLoad.empty()) {
                 auto mod = m_modsToLoad.front();
                 m_modsToLoad.pop_front();
-                log::debug("Loading mod {} {}", mod->getID(), mod->getVersion());
+                log::info("Loading mod {} {}", mod->getID(), mod->getVersion());
                 this->loadModGraph(mod, false);
                 break;
             }
             m_loadingState = LoadingState::Problems;
             [[fallthrough]];
         case LoadingState::Problems:
-            log::debug("Finding problems");
+            log::info("Finding problems");
             {
                 log::NestScope nest;
                 this->findProblems();
@@ -798,7 +798,7 @@ void Loader::Impl::continueRefreshModGraph() {
             {
                 auto end = std::chrono::high_resolution_clock::now();
                 auto time = std::chrono::duration_cast<std::chrono::milliseconds>(end - m_timerBegin).count();
-                log::info("Took {}s", static_cast<float>(time) / 1000.f);
+                log::debug("Took {}s", static_cast<float>(time) / 1000.f);
             }
             break;
         default:

--- a/loader/src/loader/Log.cpp
+++ b/loader/src/loader/Log.cpp
@@ -265,7 +265,7 @@ Severity Logger::getFileLogLevel() {
     } else if (level == "error") {
         return Severity::Error;
     } else {
-        return Severity::Warning;
+        return Severity::Info;
     }
 }
 

--- a/loader/src/loader/LogImpl.hpp
+++ b/loader/src/loader/LogImpl.hpp
@@ -3,6 +3,7 @@
 #include <Geode/DefaultInclude.hpp>
 #include <Geode/loader/Log.hpp>
 #include <Geode/loader/Mod.hpp>
+#include <Geode/loader/Types.hpp>
 #include <vector>
 #include <fstream>
 #include <string>
@@ -28,6 +29,7 @@ namespace geode::log {
 
     class Logger {
     private:
+        bool m_initialized = false;
         std::vector<Log> m_logs;
         std::ofstream m_logStream;
 
@@ -41,6 +43,8 @@ namespace geode::log {
             std::string&& content);
 
         std::vector<Log> const& list();
+        Severity getConsoleLogLevel();
+        Severity getFileLogLevel();
         void clear();
     };
 

--- a/loader/src/loader/updater.cpp
+++ b/loader/src/loader/updater.cpp
@@ -221,11 +221,11 @@ void updater::downloadLoaderResources(bool useLatestRelease) {
                 }
             }
             if (useLatestRelease) {
-                log::debug("Loader version {} does not exist, trying to download latest resources", Loader::get()->getVersion().toVString());
+                log::info("Loader version {} does not exist, trying to download latest resources", Loader::get()->getVersion().toVString());
                 downloadLatestLoaderResources();
             }
             else {
-                log::debug("Loader version {} does not exist on GitHub, not downloading the resources", Loader::get()->getVersion().toVString());
+                log::warn("Loader version {} does not exist on GitHub, not downloading the resources", Loader::get()->getVersion().toVString());
                 ResourceDownloadEvent(UpdateFinished()).post();
             }
             return *response;
@@ -361,7 +361,7 @@ void updater::checkForLoaderUpdates() {
             VersionInfo ver { 0, 0, 0 };
             root.needs("tag_name").into(ver);
 
-            log::info("Latest version is {}", ver.toVString());
+            log::info("Latest Geode version is {}", ver.toVString());
             Mod::get()->setSavedValue("latest-version-auto-update-check", ver.toVString());
 
             // make sure release is newer

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -88,8 +88,12 @@ void console::openIfClosed() {
 
     s_isOpen = true;
 
+    Severity consoleLevel = log::Logger::get()->getConsoleLogLevel();
+
     for (auto const& log : log::Logger::get()->list()) {
-        console::log(log.toString(), log.getSeverity());
+        if (log.getSeverity() >= consoleLevel) {
+            console::log(log.toString(), log.getSeverity());
+        }
     }
 }
 

--- a/loader/src/platform/windows/console.cpp
+++ b/loader/src/platform/windows/console.cpp
@@ -32,8 +32,12 @@ void setupConsole(bool forceUseEscapeCodes = false) {
         }
     }
 
+    Severity consoleLevel = log::Logger::get()->getConsoleLogLevel();
+
     for (auto const& log : log::Logger::get()->list()) {
-        console::log(log.toString(), log.getSeverity());
+        if (log.getSeverity() >= consoleLevel) {
+            console::log(log.toString(), log.getSeverity());
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements log levels, which are configurable from in-game in the Geode settings.

- There are separate log levels for the platform console and for the log files
  - platform console default: info
  - log file default: warn
- To achieve this result, I had to play around in geodeEntry(), and moved the Logger::setup() after the internal loader mod is setup, since we need access to the mod settings.
  - To assure no logs are lost, I still stored the logs in Logger::m_logs, and spit them out when calling Logger::setup()
- I also changed log levels for some messages Geode logs when loading mods
  - Most specific messages ("unzipping file", "Loading binary", "Loading hook ...") were set to debug
  - Most general level messages ("Loading mod x", "Loading resources", "Setting up crash handler", ...) were set as log::info
  - Some messages that were supposed to be warnings / errors were set to debug
- Log levels can be changed dynamically, and applying the settings will update them immediately (old logs that do not fit the new filter will not be deleted, however). New logs will respect the newly applied settings.

I would mostly like feedback about the default log levels I have set, not sure if info for the ingame console and warn for the log files is a fine choice.