### PR TITLE
Add CCGLProgram::compileShader patches to Android and macOS

### DIFF
--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -1,8 +1,6 @@
 #include <Geode/Geode.hpp>
 
 // TODO: this affects every platform :P, but i cant be bothered rn
-#ifdef GEODE_IS_WINDOWS
-
 #include <loader/LoaderImpl.hpp>
 
 using namespace geode::prelude;
@@ -15,6 +13,7 @@ $execute {
     // for some reason cocos only properly returns false on winRT, everywhere
     // else it just closes the whole game
 
+#ifdef GEODE_IS_WINDOWS
     auto addr = reinterpret_cast<uintptr_t>(
         GetProcAddress(
             GetModuleHandle("libcocos2d.dll"), "?compileShader@CCGLProgram@cocos2d@@AEAA_NPEAIIPEBD@Z"
@@ -25,9 +24,16 @@ $execute {
         0x31, 0xc0, // xor eax, eax
         0xeb, 0x07 // jmp +7 (to a nearby ret)
     });
+#elif defined(GEODE_IS_ANDROID64)
+    auto addr = reinterpret_cast<uintptr_t>(
+        dlsym(RTLD_DEFAULT, "_ZN7cocos2d11CCGLProgram13compileShaderEPjjPKc")
+    ) + 0xdc;
+
+    (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
+        0xf5, 0xff, 0xff, 0x17 // b -11 (to a nearby ret)
+    });
+#endif
 #else
     #pragma message("Unsupported GD version!")
 #endif
 };
-
-#endif

--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -30,7 +30,7 @@ $execute {
     ) + 0xdc;
 
     (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
-        0xf5, 0xff, 0xff, 0x17 // b -11 (to a nearby ret)
+        0xef, 0xff, 0xff, 0x17 // b -11 (to a nearby ret)
     });
 #endif
 #else

--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -30,7 +30,7 @@ $execute {
     ) + 0xdc;
 
     (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
-        0xef, 0xff, 0xff, 0x17 // b -11 (to a nearby ret)
+        0xef, 0xff, 0xff, 0x17 // b -17 (to a nearby ret)
     });
 #endif
 #else

--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -1,6 +1,4 @@
 #include <Geode/Geode.hpp>
-
-// TODO: this affects every platform :P, but i cant be bothered rn
 #include <loader/LoaderImpl.hpp>
 
 using namespace geode::prelude;
@@ -13,7 +11,7 @@ $execute {
     // for some reason cocos only properly returns false on winRT, everywhere
     // else it just closes the whole game
 
-#ifdef GEODE_IS_WINDOWS
+#if defined(GEODE_IS_WINDOWS)
     auto addr = reinterpret_cast<uintptr_t>(
         GetProcAddress(
             GetModuleHandle("libcocos2d.dll"), "?compileShader@CCGLProgram@cocos2d@@AEAA_NPEAIIPEBD@Z"
@@ -39,6 +37,18 @@ $execute {
 
     (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
         0x14, 0xe0 // b +2c (skip if statement)
+    });
+#elif defined(GEODE_IS_ARM_MAC)
+    auto addr = base::get() + 0x393aa0;
+
+    (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
+        0x1f, 0x20, 0x03, 0xd5 // nop (skip if statement)
+    });
+#elif defined(GEODE_IS_INTEL_MAC)
+    auto addr = base::get() + 0x417f65;
+
+    (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
+        0x48, 0x90, // nop (skip if statement)
     });
 #endif
 #else

--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -35,7 +35,9 @@ $execute {
 #elif defined(GEODE_IS_ANDROID32)
     auto addr = reinterpret_cast<uintptr_t>(
         dlsym(RTLD_DEFAULT, "_ZN7cocos2d11CCGLProgram13compileShaderEPjjPKc")
-    ) + 0x44;
+    );
+    log::info("Patching CCGLProgram::compileShader at 0x{:x} + 0x44", addr);
+    addr += 0x44;
 
     (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
         0x14, 0xe0 // b +2c (skip if statement)

--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -27,10 +27,18 @@ $execute {
 #elif defined(GEODE_IS_ANDROID64)
     auto addr = reinterpret_cast<uintptr_t>(
         dlsym(RTLD_DEFAULT, "_ZN7cocos2d11CCGLProgram13compileShaderEPjjPKc")
-    ) + 0xdc;
+    ) + 0x74;
 
     (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
-        0xef, 0xff, 0xff, 0x17 // b -17 (to a nearby ret)
+        0x1f, 0x20, 0x03, 0xd5 // nop (skip if statement)
+    });
+#elif defined(GEODE_IS_ANDROID32)
+    auto addr = reinterpret_cast<uintptr_t>(
+        dlsym(RTLD_DEFAULT, "_ZN7cocos2d11CCGLProgram13compileShaderEPjjPKc")
+    ) + 0x44;
+
+    (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
+        0x14, 0xe0 // b +2c (skip if statement)
     });
 #endif
 #else

--- a/loader/src/hooks/CompileShaderFix.cpp
+++ b/loader/src/hooks/CompileShaderFix.cpp
@@ -35,9 +35,7 @@ $execute {
 #elif defined(GEODE_IS_ANDROID32)
     auto addr = reinterpret_cast<uintptr_t>(
         dlsym(RTLD_DEFAULT, "_ZN7cocos2d11CCGLProgram13compileShaderEPjjPKc")
-    );
-    log::info("Patching CCGLProgram::compileShader at 0x{:x} + 0x44", addr);
-    addr += 0x44;
+    ) + 0x43;
 
     (void) Mod::get()->patch(reinterpret_cast<void*>(addr), {
         0x14, 0xe0 // b +2c (skip if statement)


### PR DESCRIPTION
Mat told me to use addresser, but CCGLProgram::compileShader is a private function