### PR TITLE
MacOS Microphone Permissions

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -34,6 +34,7 @@ elseif (GEODE_TARGET_PLATFORM STREQUAL "MacOS")
 	set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
 
 	target_link_libraries(${PROJECT_NAME} INTERFACE
+		"-framework AVFoundation"
 		"-framework Cocoa"
 		"-framework OpenGL"
 		"-framework SystemConfiguration"

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -225,7 +225,7 @@ int geodeEntry(void* platformData) {
         CCDictionary* plist = CCDictionary::createWithContentsOfFileThreadSafe(fmt::format("{}/Info.plist", dirs::getGameDir()).c_str());
         if (plist->objectForKey("NSMicrophoneUsageDescription") == NULL) {
             // If the microphone key doesnt exist, create it and restart game
-            auto micKeyDescription = new CCString("Geode requires microphone access for some mods to function correctly");
+            auto micKeyDescription = new CCString("A mod you have installed has requested microphone access");
             plist->setObject(micKeyDescription, "NSMicrophoneUsageDescription");
             static_cast<CCFileUtilsMac*>(CCFileUtils::get())->writeToFile(plist, fmt::format("{}/Info.plist", dirs::getGameDir()).c_str());
             micKeyDescription->release();

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -219,21 +219,7 @@ int geodeEntry(void* platformData) {
     tryLogForwardCompat();
 
 #ifdef GEODE_IS_MACOS
-    // Check if mic permissions are present in Info.plist
-    std::thread([] {
-        // Load the plist and check for microphone key
-        std::string plistPath = (dirs::getGameDir / "Info.plist").string();
-        CCDictionary* plist = CCDictionary::createWithContentsOfFileThreadSafe(plistPath.c_str());
-        if (plist->objectForKey("NSMicrophoneUsageDescription") == NULL) {
-            // If the microphone key doesnt exist, create it and restart game
-            auto micKeyDescription = new CCString("A mod you have installed has requested microphone access");
-            plist->setObject(micKeyDescription, "NSMicrophoneUsageDescription");
-            static_cast<CCFileUtilsMac*>(CCFileUtils::get())->writeToFile(plist, plistPath.c_str());
-            micKeyDescription->release();
-        }
-
-        plist->release();
-    }).detach();
+    checkPermissionPlist();
 #endif
 
     return 0;

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -3,8 +3,6 @@
 #include <loader/IPC.hpp>
 #include <loader/updater.hpp>
 
-#include <Geode/cocos/cocoa/CCDictionary.h>
-#include <Geode/cocos/platform/mac/CCFileUtilsMac.h>
 #include <Geode/loader/IPC.hpp>
 #include <Geode/loader/Loader.hpp>
 #include <Geode/loader/Log.hpp>

--- a/loader/src/load.cpp
+++ b/loader/src/load.cpp
@@ -222,12 +222,13 @@ int geodeEntry(void* platformData) {
     // Check if mic permissions are present in Info.plist
     std::thread([] {
         // Load the plist and check for microphone key
-        CCDictionary* plist = CCDictionary::createWithContentsOfFileThreadSafe(fmt::format("{}/Info.plist", dirs::getGameDir()).c_str());
+        std::string plistPath = (dirs::getGameDir / "Info.plist").string();
+        CCDictionary* plist = CCDictionary::createWithContentsOfFileThreadSafe(plistPath.c_str());
         if (plist->objectForKey("NSMicrophoneUsageDescription") == NULL) {
             // If the microphone key doesnt exist, create it and restart game
             auto micKeyDescription = new CCString("A mod you have installed has requested microphone access");
             plist->setObject(micKeyDescription, "NSMicrophoneUsageDescription");
-            static_cast<CCFileUtilsMac*>(CCFileUtils::get())->writeToFile(plist, fmt::format("{}/Info.plist", dirs::getGameDir()).c_str());
+            static_cast<CCFileUtilsMac*>(CCFileUtils::get())->writeToFile(plist, plistPath.c_str());
             micKeyDescription->release();
         }
 

--- a/loader/src/load.hpp
+++ b/loader/src/load.hpp
@@ -1,3 +1,10 @@
 #pragma once
+
+#include <Geode/platform/cplatform.h>
+
 bool safeModeCheck();
 int geodeEntry(void* platformData);
+
+#ifdef GEODE_IS_MACOS
+void checkPermissionPlist();
+#endif

--- a/loader/src/load.mm
+++ b/loader/src/load.mm
@@ -23,4 +23,18 @@ bool safeModeCheck() {
     return false;
 }
 
+void checkPermissionPlist() {
+    std::thread([] {
+        // Load the plist and check for microphone key
+        std::string plistPath = (dirs::getGameDir() / "Info.plist").string();
+        NSString* nsPlistPath = [NSString stringWithUTF8String:plistPath.c_str()];
+
+        NSMutableDictionary* plist = [NSMutableDictionary dictionaryWithContentsOfFile:nsPlistPath];
+        if (![plist objectForKey:@"NSMicrophoneUsageDescription"]) {
+            // If the microphone key doesn't exist, create it
+            [plist setObject:@"A mod you installed is requesting microphone access" forKey:@"NSMicrophoneUsageDescription"];
+            [plist writeToFile:nsPlistPath atomically:YES];
+        }
+    }).detach(); 
+}
 #endif

--- a/loader/src/platform/mac/util.mm
+++ b/loader/src/platform/mac/util.mm
@@ -5,6 +5,7 @@ using namespace geode::prelude;
 
 #include <Geode/loader/Dirs.hpp>
 #import <AppKit/AppKit.h>
+#import <AVFoundation/AVFoundation.h>
 #include <Geode/Utils.hpp>
 #include <Geode/binding/GameManager.hpp>
 #include <objc/runtime.h>
@@ -330,6 +331,8 @@ bool geode::utils::permission::getPermissionStatus(Permission permission) {
                 case AVAuthorizationStatusAuthorized: return true;
             }
         }
+
+        default: return false;
     }
 }
 

--- a/loader/src/platform/mac/util.mm
+++ b/loader/src/platform/mac/util.mm
@@ -330,12 +330,11 @@ bool geode::utils::permission::getPermissionStatus(Permission permission) {
                 case AVAuthorizationStatusDenied: return false;
                 case AVAuthorizationStatusAuthorized: return true;
             }
-        }
-
-        default: return false;
+        } break;
     }
-}
 
+    return false;
+}
 
 static std::function<void(bool)> g_permissionCallback;
 


### PR DESCRIPTION
On macOS and on game launch, this will check the Info.plist for the NSMicrophoneUsageDescription tag, if it is not found it will add it to the plist. This also implements the requestPermission method for Microphone on macOS.