### PR TITLE
Made language in installer slightly more accessible (changed EnglishExtra.nsh, SpanishExtra.nsh, and SpanishInternationalExtra.nsh)

### DIFF
--- a/installer/windows/Language Files/EnglishExtra.nsh
+++ b/installer/windows/Language Files/EnglishExtra.nsh
@@ -17,10 +17,10 @@ ${LangFileString} MUI_UNTEXT_WELCOME_INFO_TEXT "Setup will guide you through the
 
 ; installer
 
-${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\nThis path does not have Geometry Dash installed!"
+${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\nThis folder does not have Geometry Dash installed!"
 ${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\nYour version of Geometry Dash is too old for this version of Geode!"
-${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "This path has other mods installed!$\r$\nThey will be overwritten by Geode. (the dll trademark)"
+${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "This folder has other mods installed!$\r$\nThey will be overwritten by Geode. (the dll trademark)"
 
 ; uninstaller
 
-${LangFileString} GEODE_UNTEXT_GEODE_MISSING "This path does not have Geode installed!"
+${LangFileString} GEODE_UNTEXT_GEODE_MISSING "This folder does not have Geode installed!"

--- a/installer/windows/Language Files/SpanishExtra.nsh
+++ b/installer/windows/Language Files/SpanishExtra.nsh
@@ -7,10 +7,10 @@ ${LangFileString} MUI_UNTEXT_WELCOME_INFO_TEXT "Este asistente te guiará durant
 
 ; installer
 
-${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\n¡Geometry Dash no está instalado en esta ruta!"
-${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\nTu versión de Geometry Dash es muy vieja para esta versión de Geode!"
-${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "Esta ruta ya tiene otros mods instalados!$\r$\nEstos serán sobreescritos por Geode. (the dll trademark)"
+${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\n¡Geometry Dash no está instalado en este directorio!"
+${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\n¡Tu versión de Geometry Dash es muy vieja para esta versión de Geode!"
+${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "¡Este directorio ya tiene otros mods instalados!$\r$\nEstos serán sobreescritos por Geode. (the dll trademark)"
 
 ; uninstaller
 
-${LangFileString} GEODE_UNTEXT_GEODE_MISSING "¡Geode no está instalado en esta ruta!"
+${LangFileString} GEODE_UNTEXT_GEODE_MISSING "¡Geode no está instalado en este directorio!"

--- a/installer/windows/Language Files/SpanishInternationalExtra.nsh
+++ b/installer/windows/Language Files/SpanishInternationalExtra.nsh
@@ -7,10 +7,10 @@ ${LangFileString} MUI_UNTEXT_WELCOME_INFO_TEXT "Este asistente le guiará durant
 
 ; installer
 
-${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\n¡Geometry Dash no está instalado en esta ruta!"
+${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\n¡Geometry Dash no está instalado en esta carpeta!"
 ${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\n¡Su versión de Geometry Dash es demasiado antigua para esta versión de Geode!"
-${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "¡Esta ruta ya tiene otros mods instalados!$\r$\nVan a ser sobreescritos por Geode. (the dll trademark)"
+${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "¡Esta carpeta ya tiene otros mods instalados!$\r$\nVan a ser sobreescritos por Geode. (the dll trademark)"
 
 ; uninstaller
 
-${LangFileString} GEODE_UNTEXT_GEODE_MISSING "¡Geode no está instalado en esta ruta!"
+${LangFileString} GEODE_UNTEXT_GEODE_MISSING "¡Geode no está instalado en esta carpeta!"


### PR DESCRIPTION
- Changed the language to make it more accessible to users that aren't used to refer to folders with the word "path" (this is for consistency with some of the text the installer already displays)
![image](https://github.com/user-attachments/assets/a5d99244-11f7-4ce4-9ead-373922c3e68b)


- Fixed a small error in SpanishExtra.nsh: In spanish, we use the `¡` symbol to indicate the start of exclamation (and `¿` for the start of a question) and this file was missing 2 of them

I know these aren't really big changes, but I wanted to make them because the previous versions seemed weird to me.