### PR TITLE
make geode::utils::web::openLinkInBrowser open webview on android

### DIFF
--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -9,15 +9,7 @@
 
 namespace geode::utils::web {
     GEODE_DLL void openLinkInBrowser(std::string const& url);
-
-#ifdef GEODE_IS_ANDROID
-    /**
-     * Opens a native webview window in the launcher activity.
-     * @param url URL to open.
-     */
-    GEODE_DLL void openWebview(std::string const& url);
-#endif
-
+    
     // https://curl.se/libcurl/c/CURLOPT_HTTPAUTH.html
     namespace http_auth {
         constexpr static long BASIC = 0x0001;

--- a/loader/include/Geode/utils/web.hpp
+++ b/loader/include/Geode/utils/web.hpp
@@ -9,7 +9,15 @@
 
 namespace geode::utils::web {
     GEODE_DLL void openLinkInBrowser(std::string const& url);
-    
+
+#ifdef GEODE_IS_ANDROID
+    /**
+     * Opens a native webview window in the launcher activity.
+     * @param url URL to open.
+     */
+    GEODE_DLL void openWebview(std::string const& url);
+#endif
+
     // https://curl.se/libcurl/c/CURLOPT_HTTPAUTH.html
     namespace http_auth {
         constexpr static long BASIC = 0x0001;

--- a/loader/src/platform/android/util.cpp
+++ b/loader/src/platform/android/util.cpp
@@ -130,6 +130,7 @@ void utils::web::openLinkInBrowser(std::string const& url) {
         t.env->DeleteLocalRef(t.classID);
     } else {
         clearJNIException();
+        CCApplication::sharedApplication()->openURL(url.c_str());
     }
 }
 

--- a/loader/src/platform/android/util.cpp
+++ b/loader/src/platform/android/util.cpp
@@ -120,10 +120,6 @@ std::filesystem::path dirs::getModRuntimeDir() {
 }
 
 void utils::web::openLinkInBrowser(std::string const& url) {
-    CCApplication::sharedApplication()->openURL(url.c_str());
-}
-
-void utils::web::openWebview(std::string const& url) {
     JniMethodInfo t;
     if (JniHelper::getStaticMethodInfo(t, "com/geode/launcher/utils/GeodeUtils", "openWebview", "(Ljava/lang/String;)V")) {
         jstring urlArg = t.env->NewStringUTF(url.c_str());

--- a/loader/src/platform/android/util.cpp
+++ b/loader/src/platform/android/util.cpp
@@ -126,9 +126,11 @@ void utils::web::openLinkInBrowser(std::string const& url) {
 void utils::web::openWebview(std::string const& url) {
     JniMethodInfo t;
     if (JniHelper::getStaticMethodInfo(t, "com/geode/launcher/utils/GeodeUtils", "openWebview", "(Ljava/lang/String;)V")) {
-        jstring url = t.env->NewStringUTF(url.c_str());
-        t.env->CallStaticVoidMethod(t.classID, t.methodID, url);
-        t.env->DeleteLocalRef(url);
+        jstring urlArg = t.env->NewStringUTF(url.c_str());
+
+        t.env->CallStaticVoidMethod(t.classID, t.methodID, urlArg);
+
+        t.env->DeleteLocalRef(urlArg);
         t.env->DeleteLocalRef(t.classID);
     } else {
         clearJNIException();

--- a/loader/src/platform/android/util.cpp
+++ b/loader/src/platform/android/util.cpp
@@ -123,6 +123,18 @@ void utils::web::openLinkInBrowser(std::string const& url) {
     CCApplication::sharedApplication()->openURL(url.c_str());
 }
 
+void utils::web::openWebview(std::string const& url) {
+    JniMethodInfo t;
+    if (JniHelper::getStaticMethodInfo(t, "com/geode/launcher/utils/GeodeUtils", "openWebview", "(Ljava/lang/String;)V")) {
+        jstring url = t.env->NewStringUTF(url.c_str());
+        t.env->CallStaticVoidMethod(t.classID, t.methodID, url);
+        t.env->DeleteLocalRef(url);
+        t.env->DeleteLocalRef(t.classID);
+    } else {
+        clearJNIException();
+    }
+}
+
 bool utils::file::openFolder(std::filesystem::path const& path) {
     JniMethodInfo t;
     if (JniHelper::getStaticMethodInfo(t, "com/geode/launcher/utils/GeodeUtils", "openFolder", "(Ljava/lang/String;)Z")) {


### PR DESCRIPTION
Opens a browser in the launcher activity, which would prevent the game from closing.
Useful for cases where mod needs user to do something on a webpage and then return back (e.g. OAuth with local webserver)

Requires https://github.com/geode-sdk/android-launcher/pull/37