### PR TITLE
Optimize setting value changes

### DIFF
--- a/loader/src/loader/SettingNodeV3.hpp
+++ b/loader/src/loader/SettingNodeV3.hpp
@@ -222,7 +222,11 @@ protected:
         this->setValue(value, static_cast<CCNode*>(sender));
     }
     void onSlider(CCObject*) {
-        this->setValue(this->valueFromSlider(m_slider->m_touchLogic->m_thumb->getValue()), m_slider);
+        auto value = this->valueFromSlider(m_slider->m_touchLogic->m_thumb->getValue());
+
+        if (value != this->getValue()) {
+            this->setValue(value, m_slider);
+        }
     }
 
 public:

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -4,6 +4,7 @@
 #include <Geode/ui/BasedButtonSprite.hpp>
 #include <Geode/utils/file.hpp>
 #include <Geode/cocos/cocoa/CCObject.h>
+#include <Geode/loader/Event.hpp>
 #include "SwelvyBG.hpp"
 #include <Geode/ui/TextInput.hpp>
 #include <Geode/utils/ColorProvider.hpp>
@@ -91,6 +92,9 @@ bool ModsStatusNode::init() {
     m_downloadListener.bind([this](auto) { this->updateState(); });
 
     m_settingNodeListener.bind([this](SettingNodeValueChangeEvent* ev) {
+        if (!ev->isCommit()) {
+            return ListenerResult::Propagate;
+        }
         this->updateState();
         return ListenerResult::Propagate;
     });

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -7,6 +7,7 @@
 #include <Geode/ui/GeodeUI.hpp>
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/binding/ButtonSprite.hpp>
+#include <Geode/loader/Event.hpp>
 #include <Geode/loader/Loader.hpp>
 #include "server/DownloadManager.hpp"
 #include "ui/mods/GeodeStyle.hpp"
@@ -351,7 +352,10 @@ bool ModItem::init(ModSource&& source) {
     m_downloadListener.bind([this](auto) { this->updateState(); });
     m_downloadListener.setFilter(server::ModDownloadFilter(m_source.getID()));
 
-    m_settingNodeListener.bind([this](SettingNodeValueChangeEvent*) {
+    m_settingNodeListener.bind([this](SettingNodeValueChangeEvent* ev) {
+        if (!ev->isCommit()) {
+            return ListenerResult::Propagate;
+        }
         this->updateState();
         return ListenerResult::Propagate;
     });

--- a/loader/src/ui/mods/popups/ModPopup.cpp
+++ b/loader/src/ui/mods/popups/ModPopup.cpp
@@ -6,6 +6,7 @@
 #include <Geode/ui/MDTextArea.hpp>
 #include <Geode/ui/TextInput.hpp>
 #include <Geode/utils/web.hpp>
+#include <Geode/loader/Event.hpp>
 #include <Geode/loader/Loader.hpp>
 #include <Geode/loader/ModSettingsManager.hpp>
 #include <Geode/ui/GeodeUI.hpp>
@@ -646,7 +647,10 @@ bool ModPopup::setup(ModSource&& src) {
     m_downloadListener.bind([this](auto) { this->updateState(); });
     m_downloadListener.setFilter(m_source.getID());
 
-    m_settingNodeListener.bind([this](SettingNodeValueChangeEvent*) {
+    m_settingNodeListener.bind([this](SettingNodeValueChangeEvent* ev) {
+        if (!ev->isCommit()) {
+            return ListenerResult::Propagate;
+        }
         this->updateState();
         return ListenerResult::Propagate;
     });


### PR DESCRIPTION
On every setting update (commited or not), updateState would be called in ModsLayer, ModPopup (if it's active), and all ModItems. This obviously led to bad performance.

This PR just checks if the value change is commited before calling updateState on ModsLayer, ModItem and ModPopup