### PR TITLE
Random fixes for ModsLayer

### DIFF
--- a/loader/src/ui/mods/list/ModDeveloperList.cpp
+++ b/loader/src/ui/mods/list/ModDeveloperList.cpp
@@ -6,6 +6,7 @@
 #include <Geode/cocos/platform/CCPlatformMacros.h>
 #include <Geode/utils/cocos.hpp>
 #include <Geode/ui/ScrollLayer.hpp>
+#include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/loader/Loader.hpp>
 #include <Geode/loader/Mod.hpp>
 #include <GUI/CCControlExtension/CCScale9Sprite.h>
@@ -36,10 +37,10 @@ bool ModDeveloperList::init(DevListPopup* popup, ModSource const& source, CCSize
     // mfw fod created a scrolllayer with layouts
     m_list = ScrollLayer::create({ size.width - 10.f, size.height - 10.f });
     m_list->m_contentLayer->setLayout(
-        ColumnLayout::create()
-            ->setAxisReverse(true)
-            ->setAxisAlignment(AxisAlignment::End)
-            ->setAutoGrowAxis(size.height)
+        SimpleColumnLayout::create()
+            ->setMainAxisDirection(AxisDirection::BottomToTop)
+            ->setMainAxisAlignment(MainAxisAlignment::End)
+            ->setMainAxisScaling(AxisScaling::Grow)
             ->setGap(5.0f)
     );
     this->addChildAtPosition(

--- a/loader/src/ui/mods/popups/ModPopup.cpp
+++ b/loader/src/ui/mods/popups/ModPopup.cpp
@@ -506,13 +506,17 @@ bool ModPopup::setup(ModSource&& src) {
             spr->setColor({ 155, 155, 155 });
             spr->setOpacity(155);
         }
+
+        SEL_MenuHandler handler = std::get<2>(stat).has_value() ?
+            (std::get<3>(stat) ? std::get<3>(stat) : menu_selector(ModPopup::onLink)) : 
+            nullptr;
+
         auto btn = CCMenuItemSpriteExtra::create(
-            spr, this, (
-                std::get<2>(stat).has_value() ?
-                    (std::get<3>(stat) ? std::get<3>(stat) : menu_selector(ModPopup::onLink)) : 
-                    nullptr
-            )
+            spr, this, handler
         );
+
+        btn->setEnabled(handler != nullptr);
+
         btn->setID(std::get<0>(stat));
         if (!std::get<3>(stat) && std::get<2>(stat)) {
             btn->setUserObject("url", CCString::create(*std::get<2>(stat)));


### PR DESCRIPTION
- Use `SimpleAxisLayout` for `ModDeveloperList`, fixes #953 
- Set link buttons as disabled if mod doesn't have the specific link to disable the button animation, fixes #955 