### PR TITLE
Allow BreakLine to be included for any mod

### DIFF
--- a/loader/include/Geode/ui/BreakLine.hpp
+++ b/loader/include/Geode/ui/BreakLine.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cocos2d.h>
+
+namespace geode {
+    class GEODE_DLL BreakLine : public cocos2d::CCNode {
+    protected:
+        cocos2d::ccColor4F m_color;
+
+        void draw() override;
+        bool init(float width, float height, cocos2d::ccColor4F color);
+    public:
+        /**
+         * Create a break line to act as a separator
+         * @param width Width of the line
+         * @param height Height of the line
+         * @param color The color of the line
+         */
+        static BreakLine* create(
+            float width,
+            float height = 1.f,
+            cocos2d::ccColor4F color = {1.f, 1.f, 1.f, .2f}
+        );
+    };
+}

--- a/loader/src/ui/nodes/BreakLine.cpp
+++ b/loader/src/ui/nodes/BreakLine.cpp
@@ -1,0 +1,32 @@
+#include <cocos2d.h>
+#include <Geode/ui/BreakLine.hpp>
+
+using namespace geode::prelude;
+
+bool BreakLine::init(float width, float height, ccColor4F color) {
+    if (!CCNode::init())
+        return false;
+
+    this->setContentSize({ width, height });
+    m_color = color;
+
+    return true;
+}
+
+void BreakLine::draw() {
+    // some nodes sometimes set the blend func to
+    // something else without resetting it back
+    ccGLBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    ccDrawSolidRect({ 0, 0 }, this->getContentSize(), m_color);
+    CCNode::draw();
+}
+
+BreakLine* BreakLine::create(float width, float height, ccColor4F color) {
+    auto ret = new BreakLine;
+    if (ret->init(width, height, color)) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}

--- a/loader/src/ui/nodes/MDTextArea.cpp
+++ b/loader/src/ui/nodes/MDTextArea.cpp
@@ -7,6 +7,7 @@
 #include <Geode/loader/Mod.hpp>
 #include <Geode/loader/Loader.hpp>
 #include <Geode/ui/MDTextArea.hpp>
+#include <Geode/ui/BreakLine.hpp>
 #include <Geode/utils/casts.hpp>
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/web.hpp>
@@ -155,29 +156,6 @@ bool MDTextArea::init(std::string const& str, CCSize const& size) {
 MDTextArea::~MDTextArea() {
     CC_SAFE_RELEASE(m_renderer);
 }
-
-class BreakLine : public CCNode {
-protected:
-    void draw() override {
-        // some nodes sometimes set the blend func to
-        // something else without resetting it back
-        ccGLBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        ccDrawSolidRect({ 0, 0 }, this->getContentSize(), { 1.f, 1.f, 1.f, .2f });
-        CCNode::draw();
-    }
-
-public:
-    static BreakLine* create(float width) {
-        auto ret = new BreakLine;
-        if (ret->init()) {
-            ret->autorelease();
-            ret->setContentSize({ width, 1.f });
-            return ret;
-        }
-        delete ret;
-        return nullptr;
-    }
-};
 
 void MDTextArea::onLink(CCObject* pSender) {
     auto href = as<CCString*>(as<CCNode*>(pSender)->getUserObject());


### PR DESCRIPTION
This change moves BreakLine out of the source file into its own header file and class, allowing it to be included for any other mod that wants to use it.