### PR TITLE
Lazy loaded sprite

### DIFF
--- a/loader/include/Geode/ui/LazySprite.hpp
+++ b/loader/include/Geode/ui/LazySprite.hpp
@@ -2,6 +2,7 @@
 
 #include "LoadingSpinner.hpp"
 #include <Geode/utils/web.hpp>
+#include <Geode/utils/cocos.hpp>
 
 #include <cocos2d.h>
 #include <filesystem>

--- a/loader/include/Geode/ui/LazySprite.hpp
+++ b/loader/include/Geode/ui/LazySprite.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "LoadingSpinner.hpp"
+#include <Geode/utils/web.hpp>
+
+#include <cocos2d.h>
+#include <filesystem>
+#include <stdint.h>
+
+namespace geode {
+    /**
+     * A sprite that is initialized that is loaded asynchronously.
+     * It can be initialized to either a blank texture or a loading circle,
+     * and then given either a URL, file path, or raw image data that will be processed
+     * in the background to avoid freezes.
+     */
+    class GEODE_DLL LazySprite : public cocos2d::CCSprite {
+    public:
+        using Callback = std::function<void(Result<>)>;
+        using Format = cocos2d::CCImage::EImageFormat;
+
+        static LazySprite* create(cocos2d::CCSize size, bool loadingCircle = true);
+
+        void loadFromUrl(std::string const& url, Format format = Format::kFmtUnKnown, bool ignoreCache = false);
+        void loadFromUrl(char const* url, Format format = Format::kFmtUnKnown, bool ignoreCache = false);
+        void loadFromFile(std::filesystem::path const& path, Format format = Format::kFmtUnKnown, bool ignoreCache = false);
+        void loadFromData(std::span<uint8_t const> data, Format format = Format::kFmtUnKnown);
+        void loadFromData(uint8_t const* ptr, size_t size, Format format = Format::kFmtUnKnown);
+        void loadFromData(std::vector<uint8_t> data, Format format = Format::kFmtUnKnown);
+
+        /**
+         * Set the callback to be called once the sprite is fully loaded, or an error occurred.
+         * @param callback The callback
+         */
+        void setLoadCallback(Callback callback);
+
+        /**
+         * Set whether the image will be automatically resized to the size given in the `create` / `init` function
+         * once it's loaded. By default is `false`.
+         */
+        void setAutoResize(bool value);
+
+        /**
+         * Returns whether the image is now loaded
+         */
+        bool isLoaded();
+        bool isLoading();
+
+        virtual bool initWithTexture(cocos2d::CCTexture2D* texture) override;
+        virtual bool initWithTexture(cocos2d::CCTexture2D* pTexture, const cocos2d::CCRect& rect) override;
+        virtual bool initWithSpriteFrame(cocos2d::CCSpriteFrame* pSpriteFrame) override;
+        virtual bool initWithSpriteFrameName(const char* pszSpriteFrameName) override;
+        virtual bool initWithFile(const char* pszFilename) override;
+        virtual bool initWithFile(const char* pszFilename, const cocos2d::CCRect& rect) override;
+
+    protected:
+        Ref<LoadingSpinner> m_loadingCircle;
+        Callback m_callback;
+        Format m_expectedFormat;
+        EventListener<utils::web::WebTask> m_listener;
+        bool m_isLoading = false;
+        bool m_hasLoaded = false;
+        cocos2d::CCSize m_targetSize;
+        bool m_autoresize;
+
+        bool init(cocos2d::CCSize size, bool loadingCircle = true);
+        void doInitFromBytes(std::vector<uint8_t> data, std::string cacheKey);
+        std::string makeCacheKey(std::filesystem::path const& path);
+        // std::string makeCacheKey(std::string_view url);
+
+        cocos2d::CCTexture2D* lookupCache(char const* key);
+        bool initFromCache(char const* key);
+        bool postInit(bool initResult);
+
+        void onError(std::string err);
+    };
+}

--- a/loader/include/Geode/ui/LazySprite.hpp
+++ b/loader/include/Geode/ui/LazySprite.hpp
@@ -5,6 +5,9 @@
 
 #include <cocos2d.h>
 #include <filesystem>
+#include <string>
+#include <functional>
+#include <span>
 #include <stdint.h>
 
 namespace geode {

--- a/loader/include/Geode/ui/LazySprite.hpp
+++ b/loader/include/Geode/ui/LazySprite.hpp
@@ -9,7 +9,7 @@
 
 namespace geode {
     /**
-     * A sprite that is initialized that is loaded asynchronously.
+     * A sprite that is loaded asynchronously.
      * It can be initialized to either a blank texture or a loading circle,
      * and then given either a URL, file path, or raw image data that will be processed
      * in the background to avoid freezes.

--- a/loader/include/Geode/ui/LazySprite.hpp
+++ b/loader/include/Geode/ui/LazySprite.hpp
@@ -14,7 +14,7 @@ namespace geode {
      * and then given either a URL, file path, or raw image data that will be processed
      * in the background to avoid freezes.
      */
-    class GEODE_DLL LazySprite : public cocos2d::CCSprite {
+    class GEODE_DLL LazySprite final : public cocos2d::CCSprite {
     public:
         using Callback = std::function<void(Result<>)>;
         using Format = cocos2d::CCImage::EImageFormat;
@@ -53,15 +53,15 @@ namespace geode {
         virtual bool initWithFile(const char* pszFilename) override;
         virtual bool initWithFile(const char* pszFilename, const cocos2d::CCRect& rect) override;
 
-    protected:
+    private:
         Ref<LoadingSpinner> m_loadingCircle;
         Callback m_callback;
         Format m_expectedFormat;
         EventListener<utils::web::WebTask> m_listener;
         bool m_isLoading = false;
         bool m_hasLoaded = false;
-        cocos2d::CCSize m_targetSize;
         bool m_autoresize;
+        cocos2d::CCSize m_targetSize;
 
         bool init(cocos2d::CCSize size, bool loadingCircle = true);
         void doInitFromBytes(std::vector<uint8_t> data, std::string cacheKey);

--- a/loader/src/ui/GeodeUI.cpp
+++ b/loader/src/ui/GeodeUI.cpp
@@ -3,6 +3,7 @@
 #include <Geode/ui/GeodeUI.hpp>
 #include <Geode/ui/MDPopup.hpp>
 #include <Geode/ui/LoadingSpinner.hpp>
+#include <Geode/ui/LazySprite.hpp>
 #include <Geode/utils/web.hpp>
 #include <server/Server.hpp>
 #include "mods/GeodeStyle.hpp"
@@ -199,16 +200,19 @@ using ModLogoSrc = std::variant<Mod*, std::string, std::filesystem::path>;
 
 class ModLogoSprite : public CCNode {
 protected:
+    LazySprite* m_sprite;
     std::string m_modID;
-    CCNode* m_sprite = nullptr;
     EventListener<server::ServerRequest<ByteVector>> m_listener;
 
     bool init(ModLogoSrc&& src) {
         if (!CCNode::init())
             return false;
-        
+
         this->setAnchorPoint({ .5f, .5f });
         this->setContentSize({ 50, 50 });
+
+        m_sprite = LazySprite::create(this->getContentSize());
+        this->addChildAtPosition(m_sprite, Anchor::Center);
 
         m_listener.bind(this, &ModLogoSprite::onFetch);
     
@@ -216,26 +220,37 @@ protected:
             [this](Mod* mod) {
                 m_modID = mod->getID();
 
+                m_sprite->setLoadCallback([this](Result<> res) {
+                    this->onLoaded(std::move(res));
+                });
+
                 // Load from Resources
-                this->setSprite(mod->isInternal() ? 
-                    CCSprite::createWithSpriteFrameName("geode-logo.png"_spr) : 
-                    CCSprite::create(fmt::format("{}/logo.png", mod->getID()).c_str()),
-                    false
-                );
+                if (!mod->isInternal()) {
+                    m_sprite->loadFromFile(dirs::getModRuntimeDir() / mod->getID() / "logo.png");
+                } else {
+                    m_sprite->initWithSpriteFrameName("geode-logo.png"_spr);
+                }
             },
             [this](std::string const& id) {
                 m_modID = id;
                 
                 // Asynchronously fetch from server
-                this->setSprite(createLoadingCircle(25), false);
                 m_listener.setFilter(server::getModLogo(id));
             },
             [this](std::filesystem::path const& path) {
-                this->setSprite(nullptr, false);
+                m_sprite->setLoadCallback([this](Result<> res) {
+                    this->onLoaded(std::move(res));
+                });
+
                 if (auto unzip = file::Unzip::create(path)) {
                     if (auto logo = unzip.unwrap().extract("logo.png")) {
-                        this->setSprite(std::move(logo.unwrap()), false);
+                        m_sprite->loadFromData(std::move(logo).unwrap());
                     }
+                }
+                
+                // if the logo.png was not found then switch to fallback label
+                if (!m_sprite->isLoading()) {
+                    this->onLoadFailed(true);
                 }
             },
         }, src);
@@ -248,49 +263,48 @@ protected:
         return true;
     }
 
-    void setSprite(CCNode* sprite, bool postEvent) {
-        // Remove any existing sprite
-        if (m_sprite) {
-            m_sprite->removeFromParent();
-        }
-        // Fallback to default logo if the sprite is null
-        if (!sprite || sprite->getUserObject("geode.texture-loader/fallback")) {
-            sprite = CCLabelBMFont::create("N/A", "bigFont.fnt");
-            static_cast<CCLabelBMFont*>(sprite)->setOpacity(90);
-        }
-        // Set sprite and scale it to node size
-        m_sprite = sprite;
-        m_sprite->setID("sprite");
-        limitNodeSize(m_sprite, m_obContentSize, 99.f, 0.f);
-        this->addChildAtPosition(m_sprite, Anchor::Center);
-
-        if (postEvent) {
-            ModLogoUIEvent(std::make_unique<ModLogoUIEvent::Impl>(this, m_modID)).post();
-        }
+    void doPostEvent() {
+        ModLogoUIEvent(std::make_unique<ModLogoUIEvent::Impl>(this, m_modID)).post();
     }
-    void setSprite(ByteVector&& data, bool postEvent) {
-        auto image = new CCImage();
-        image->initWithImageData(data.data(), data.size());
 
-        auto texture = CCTextureCache::get()->addUIImage(image, m_modID.c_str());
-        image->release();
+    void onLoaded(Result<> res) {
+        if (!res) {
+            log::debug("Failed to load image: {}", res.err().value_or(std::string{}));
+            this->onLoadFailed(true);
+            return;
+        }
 
-        this->setSprite(CCSprite::createWithTexture(texture), postEvent);
+        limitNodeSize(m_sprite, m_obContentSize, 99.f, 0.f);
+        this->doPostEvent();
+    }
+
+    void onLoadFailed(bool postEvent) {
+        // Fallback to default logo if the image failed to load
+        auto sprite = CCLabelBMFont::create("N/A", "bigFont.fnt");
+        sprite->setPosition(this->getScaledContentSize() / 2.f + CCSize{1.f, 2.f});
+        sprite->setOpacity(90);
+        limitNodeSize(sprite, m_obContentSize, 99.f, 0.f);
+        this->addChildAtPosition(sprite, Anchor::Center);
+        
+        this->doPostEvent();
     }
 
     void onFetch(server::ServerRequest<ByteVector>::Event* event) {
         if (auto result = event->getValue()) {
             // Set default sprite on error
             if (result->isErr()) {
-                this->setSprite(nullptr, true);
+                this->onLoadFailed(true);
             }
             // Otherwise load downloaded sprite to memory
             else {
-                this->setSprite(std::move(result->unwrap()), true);
+                m_sprite->setLoadCallback([this](Result<> res) {
+                    this->onLoaded(std::move(res));
+                });
+                m_sprite->loadFromData(std::move(result->unwrap()));
             }
         }
         else if (event->isCancelled()) {
-            this->setSprite(nullptr, true);
+            this->onLoadFailed(true);
         }
     }
 

--- a/loader/src/ui/nodes/LazySprite.cpp
+++ b/loader/src/ui/nodes/LazySprite.cpp
@@ -1,0 +1,421 @@
+#include <Geode/ui/LazySprite.hpp>
+#include <Geode/utils/string.hpp>
+#include <Geode/utils/web.hpp>
+#include <Geode/utils/file.hpp>
+
+#include <thread>
+#include <queue>
+#include <condition_variable>
+
+using namespace geode::prelude;
+
+namespace {
+
+// mini threadpool type thing
+class Manager {
+public:
+    using Task = std::function<void()>;
+
+    static Manager& get() {
+        static Manager instance;
+        return instance;
+    }
+
+    Manager() {}
+
+    ~Manager() {
+        this->stopThreads();
+    }
+
+    Manager(const Manager&) = delete;
+    Manager& operator=(const Manager&) = delete;
+    Manager(Manager&&) = delete;
+    Manager& operator=(Manager&&) = delete;
+
+    void pushTask(Task task) {
+        bool anyFree = false;
+        for (size_t i = 0; i < m_threadsInit; i++) {
+            if (!m_threadsBusy[i]) {
+                anyFree = true;
+                break;
+            }
+        }
+
+        if (!anyFree) {
+            this->tryAllocThread();
+        }
+
+        std::unique_lock lock(m_mutex);
+        m_tasks.emplace(std::move(task));
+        m_condvar.notify_one();
+    }
+
+private:
+    static constexpr size_t MAX_THREADS = 2;
+    size_t m_threadsInit = 0;
+
+    std::mutex m_mutex; // guards the queue
+    std::queue<Task> m_tasks;
+    std::array<std::thread, MAX_THREADS> m_threads;
+    std::array<std::atomic_bool, MAX_THREADS> m_threadsBusy;
+    std::condition_variable m_condvar;
+    std::atomic_bool m_requestedStop;
+
+    std::function<void()> threadPickTask(std::unique_lock<std::mutex>& lock) {
+        auto task = std::move(m_tasks.front());
+        m_tasks.pop();
+        return task;
+    }
+
+    bool threadWait(std::unique_lock<std::mutex>& lock) {
+        if (!m_tasks.empty()) return true;
+
+        m_condvar.wait_for(lock, std::chrono::milliseconds{50}, [&] {
+            return !m_tasks.empty();
+        });
+
+        return !m_tasks.empty();
+    }
+
+    void threadFunc(size_t idx) {
+        while (!m_requestedStop) {
+            m_threadsBusy[idx] = false;
+
+            std::unique_lock lock(m_mutex);
+
+            if (!this->threadWait(lock)) {
+                continue;
+            }
+
+            m_threadsBusy[idx] = true;
+
+            auto task = this->threadPickTask(lock);
+            lock.unlock();
+
+            task();
+        }
+    }
+
+    void tryAllocThread() {
+        if (m_threadsInit >= MAX_THREADS) return;
+
+        m_threads[m_threadsInit] = std::thread(&Manager::threadFunc, this, m_threadsInit);
+        m_threadsInit++;
+    }
+
+    void stopThreads() {
+        m_requestedStop.store(true);
+
+        for (size_t i = 0; i < m_threadsInit; i++) {
+            if (m_threads[i].joinable()) m_threads[i].join();
+        }
+    }
+};
+
+}
+
+bool LazySprite::init(CCSize size, bool loadingCircle) {
+    if (!CCSprite::init()) return false;
+
+    m_isLoading = false;
+    m_hasLoaded = false;
+
+    if (loadingCircle) {
+        float lcsize = std::min<float>(size.width, size.height);
+
+        m_loadingCircle = LoadingSpinner::create(lcsize);
+        m_loadingCircle->setAnchorPoint({0.5f, 0.5f});
+        m_loadingCircle->setPosition(size / 2.f);
+        this->addChild(m_loadingCircle);
+    }
+
+    this->setContentSize(size);
+
+    m_targetSize = size;
+    m_autoresize = false;
+
+    return true;
+}
+
+void LazySprite::loadFromUrl(const std::string& url, Format format, bool ignoreCache) {
+    return this->loadFromUrl(url.c_str(), format, ignoreCache);
+}
+
+void LazySprite::loadFromUrl(char const* url, Format format, bool ignoreCache) {
+    if (m_isLoading || m_hasLoaded) {
+        return;
+    }
+
+    if (!ignoreCache && this->initFromCache(url)) {
+        return;
+    }
+    
+    m_expectedFormat = format;
+    m_isLoading = true;
+
+    m_listener.bind([this, cacheKey = std::string(url)](web::WebTask::Event* event) mutable {
+        if (!event || !event->getValue()) return;
+
+        auto resp = event->getValue();
+        if (!resp->ok()) {
+            std::string errmsg = resp->errorMessage();
+            if (errmsg.empty()) {
+                errmsg = resp->string().unwrapOrDefault();
+            }
+
+            if (errmsg.size() > 127) {
+                errmsg.resize(124);
+                errmsg += "...";
+            }
+
+            this->onError(fmt::format(
+                "Request failed (code {}): {}",
+                resp->code(),
+                errmsg
+            ));
+
+            return;
+        }
+
+        auto data = resp->data();
+        this->doInitFromBytes(std::move(data), std::move(cacheKey));
+    });
+
+    web::WebRequest req{};
+    m_listener.setFilter(req.get(url));
+}
+
+void LazySprite::loadFromFile(const std::filesystem::path& path, Format format, bool ignoreCache) {
+    if (m_isLoading || m_hasLoaded) {
+        return;
+    }
+
+    auto cacheKey = ignoreCache ? std::string{} : this->makeCacheKey(path);
+    if (!ignoreCache && this->initFromCache(cacheKey.c_str())) {
+        return;
+    }
+
+    m_expectedFormat = format;
+    m_isLoading = true;
+
+    Manager::get().pushTask([
+        selfref = WeakRef(this),
+        path = path,
+        cacheKey = std::move(cacheKey)
+    ]() mutable {
+        auto res = utils::file::readBinary(path);
+
+        // oh god
+        Loader::get()->queueInMainThread([
+            selfref = std::move(selfref),
+            path = std::move(path),
+            cacheKey = std::move(cacheKey),
+            res = std::move(res)
+        ]() mutable {
+            auto self = selfref.lock();
+            if (!self) return;
+    
+            if (!res) { 
+                self->onError(fmt::format("failed to load from file: {}", res.unwrapErr()));
+                return;
+            }
+    
+            self->doInitFromBytes(std::move(res).unwrap(), std::move(cacheKey));
+        });
+    });
+}
+
+void LazySprite::loadFromData(std::span<uint8_t const> data, Format format) {
+    this->loadFromData(data.data(), data.size(), format);
+}
+
+void LazySprite::loadFromData(uint8_t const* ptr, size_t size, Format format) {
+    this->loadFromData(std::vector(ptr, ptr + size), format);
+}
+
+void LazySprite::loadFromData(std::vector<uint8_t> data, Format format) {
+    if (m_isLoading || m_hasLoaded) {
+        return;
+    }
+
+    m_expectedFormat = format;
+    m_isLoading = true;
+
+    this->doInitFromBytes(data, "");
+}
+
+void LazySprite::doInitFromBytes(std::vector<uint8_t> data, std::string cacheKey) {
+    // do initialization in the threadpool
+    Manager::get().pushTask([
+        selfref = WeakRef(this),
+        data = std::move(data),
+        cacheKey = std::move(cacheKey),
+        format = m_expectedFormat
+    ]() mutable {
+        auto image = new CCImage();
+        bool res = image->initWithImageData(data.data(), data.size(), format);
+
+        auto self = selfref.lock();
+        if (!self) {
+            delete image;
+            return;
+        }
+
+        if (!res) {
+            delete image;
+
+            Loader::get()->queueInMainThread([selfref = std::move(selfref)]() mutable {
+                auto self = selfref.lock();
+                if (self) {
+                    self->onError("invalid image data");
+                }
+            });
+
+            return;
+        }
+
+        // image initialization succeeded, all we need to do now is to
+        // create the opengl texture (must be on main thread!) and then set this sprite to use that.
+
+        Loader::get()->queueInMainThread([
+            selfref = std::move(selfref),
+            image,
+            cacheKey = std::move(cacheKey)
+        ] {
+            auto self = selfref.lock();
+            if (!self) return;
+
+            auto texture = new CCTexture2D();
+            if (!texture->initWithImage(image)) {
+                delete texture;
+                image->release();
+                self->onError("failed to initialize OpenGL texture");
+                return;
+            }
+
+            // store texture
+            CCTextureCache::get()->m_pTextures->setObject(texture, cacheKey.c_str());
+
+            image->release();   // deallocate the image, not needed anymore
+            texture->release(); // bring texture's refcount back to 1
+
+            if (!self->initWithTexture(texture)) {
+                // this should never happen tbh
+                self->onError("failed to initialize the sprite");
+            }
+        });
+    });
+}
+
+std::string LazySprite::makeCacheKey(std::filesystem::path const& path) {
+#ifdef GEODE_IS_WINDOWS
+    std::string p = geode::utils::string::wideToUtf8(path.wstring());
+#else
+    std::string p = path.string();
+#endif
+
+    return p;
+}
+
+CCTexture2D* LazySprite::lookupCache(char const* key) {
+    return static_cast<CCTexture2D*>(CCTextureCache::get()->m_pTextures->objectForKey(key));
+}
+
+bool LazySprite::initFromCache(char const* key) {
+    if (auto tex = this->lookupCache(key)) {
+        return this->initWithTexture(tex);
+    }
+
+    return false;
+}
+
+/* It's not impossible to optimize those too, but I did not bother for now, so they are just forwarders */
+
+bool LazySprite::initWithTexture(CCTexture2D* texture, const CCRect& rect) {
+    return this->postInit(CCSprite::initWithTexture(texture, rect));
+}
+
+bool LazySprite::initWithTexture(CCTexture2D* texture) {
+    return this->postInit(CCSprite::initWithTexture(texture));
+}
+
+bool LazySprite::initWithSpriteFrame(CCSpriteFrame* sf) {
+    return this->postInit(CCSprite::initWithSpriteFrame(sf));
+}
+
+bool LazySprite::initWithSpriteFrameName(const char* fn) {
+    return this->postInit(CCSprite::initWithSpriteFrameName(fn));
+}
+
+bool LazySprite::initWithFile(const char* fn) {
+    return this->postInit(CCSprite::initWithFile(fn));
+}
+
+bool LazySprite::initWithFile(const char* fn, const CCRect& rect) {
+    return this->postInit(CCSprite::initWithFile(fn, rect));
+}
+
+/* end forwarders */
+
+bool LazySprite::postInit(bool initResult) {
+    m_hasLoaded = initResult;
+    m_isLoading = false;
+
+    if (!initResult) return false;
+
+    if (m_autoresize) {
+        limitNodeSize(this, m_targetSize, std::min<float>(m_targetSize.width, m_targetSize.height), 0.f);
+    }
+
+    if (m_callback) {
+        m_callback(Ok());
+    }
+
+    if (m_loadingCircle) {
+        m_loadingCircle->removeFromParent();
+        m_loadingCircle = nullptr;
+    }
+
+    return true;
+}
+
+void LazySprite::onError(std::string err) {
+    m_hasLoaded = false;
+    m_isLoading = false;
+
+    if (m_callback) {
+        m_callback(Err(std::move(err)));
+    }
+
+    if (m_loadingCircle) {
+        m_loadingCircle->removeFromParent();
+        m_loadingCircle = nullptr;
+    }
+}
+
+void LazySprite::setLoadCallback(Callback callback) {
+    m_callback = std::move(callback);
+}
+
+void LazySprite::setAutoResize(bool value) {
+    m_autoresize = value;
+}
+
+bool LazySprite::isLoaded() {
+    return m_hasLoaded;
+}
+
+bool LazySprite::isLoading() {
+    return m_isLoading;
+}
+
+LazySprite* LazySprite::create(CCSize size, bool loadingCircle) {
+    auto ret = new LazySprite;
+    if (ret->init(size, loadingCircle)) {
+        ret->autorelease();
+        return ret;
+    }
+
+    delete ret;
+    return nullptr;
+}


### PR DESCRIPTION
Adds a new class `geode::LazySprite`, which has APIs for loading an image from the internet, from a file, or from binary data.

Performs as much processing as possible in a background thread, to avoid freezes, and uses a lightweight threadpool, hence it's recommended that all mod developers who manually create images should use this class instead.

TODO: more docstrings and a docs page