### PR TITLE
Switch almost all AxisLayouts to SimpleAxisLayouts

### DIFF
--- a/loader/src/cocos2d-ext/SimpleAxisLayout.cpp
+++ b/loader/src/cocos2d-ext/SimpleAxisLayout.cpp
@@ -79,7 +79,7 @@ public:
 
     std::unordered_map<CCNode*, float> calculateCrossScaling(CCNode* layout, std::vector<CCNode*> const& nodes);
     std::unordered_map<CCNode*, float> calculateMainScaling(CCNode* layout, std::vector<CCNode*> const& nodes, float totalGap);
-    
+
     void applyCrossPositioning(CCNode* layout, std::vector<CCNode*> const& nodes);
     void applyMainPositioning(CCNode* layout, std::vector<CCNode*> const& nodes, std::vector<SpacerNode*> const& spacers, float totalGap);
 
@@ -161,7 +161,13 @@ public:
         return on->getScale();
     }
 
+    float getUncommitedScale(CCNode* on) {
+        return m_originalScalesPerNode[on] * m_relativeScalesPerNode[on];
+    }
+
     void setScale(CCNode* on, float scale) {
+        if (on->getScale() == scale) return;
+
         // CCMenuItemSpriteExtra is quirky af
         if (auto btn = typeinfo_cast<CCMenuItemSpriteExtra*>(on)) {
             btn->m_baseScale = scale;
@@ -195,9 +201,9 @@ public:
 
     // get the maximum allowed scale for the node
     // based on the layout's width and the node's width
-    float getMaxCrossScale(CCNode* layout, CCNode* on) const {
+    float getMaxCrossScale(CCNode* layout, CCNode* on) {
         auto const layoutWidth = this->getContentWidth(layout);
-        auto const width = this->getContentWidth(on) * this->getScale(on);
+        auto const width = this->getContentWidth(on) * this->getUncommitedScale(on);
         auto const maxAllowedScale = layoutWidth / width;
         auto const maxScale = this->getMaxScale(on);
         if (maxScale) return std::min(maxAllowedScale, *maxScale);
@@ -213,7 +219,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateCrossScaling
 
     // get the limits we are working with
     for (auto node : nodes) {
-        auto const width = this->getContentWidth(node) * this->getScale(node);
+        auto const width = this->getContentWidth(node) * this->getUncommitedScale(node);
         if (width > maxWidth) {
             maxWidth = width;
         }
@@ -239,7 +245,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateCrossScaling
         switch (m_crossAxisScaling) {
             case AxisScaling::ScaleDownGaps:
             case AxisScaling::ScaleDown: {
-                auto const width = this->getContentWidth(node) * this->getScale(node);
+                auto const width = this->getContentWidth(node) * this->getUncommitedScale(node);
                 auto const minScale = this->getMinScale(node);
 
                 // scale down if needed
@@ -249,7 +255,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateCrossScaling
                 break;
             }
             case AxisScaling::Scale: {
-                auto const width = this->getContentWidth(node) * this->getScale(node);
+                auto const width = this->getContentWidth(node) * this->getUncommitedScale(node);
                 auto const minScale = this->getMinScale(node);
                 auto const maxScale = this->getMaxCrossScale(layout, node);
 
@@ -274,7 +280,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
 
     // get the limits we are working with
     for (auto node : nodes) {
-        auto const height = this->getContentHeight(node) * this->getScale(node);
+        auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
         totalHeight += height;
     }
 
@@ -316,7 +322,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
         switch (m_mainAxisScaling) {
             case AxisScaling::ScaleDownGaps:
             case AxisScaling::ScaleDown: {
-                auto const height = this->getContentHeight(node) * this->getScale(node);
+                auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
                 auto const minScale = this->getMinScale(node);
 
                 // scale down if needed
@@ -327,7 +333,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
                 break;
             }
             case AxisScaling::Scale: {
-                auto const height = this->getContentHeight(node) * this->getScale(node);
+                auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
                 auto const minScale = this->getMinScale(node);
                 auto const maxScale = this->getMaxCrossScale(layout, node);
 
@@ -382,9 +388,9 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
         }
     }
 
-    for (auto priority : { 
-        ScalingPriority::First, ScalingPriority::Early, ScalingPriority::Normal, 
-        ScalingPriority::Late, ScalingPriority::Last 
+    for (auto priority : {
+        ScalingPriority::First, ScalingPriority::Early, ScalingPriority::Normal,
+        ScalingPriority::Late, ScalingPriority::Last
     }) {
         if (totalHeight > layoutHeight) {
             // scale down the nodes, we are over the limit
@@ -394,7 +400,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
                 // only partially scale down, should be the last priority to scale
                 auto priorityHeight = 0.f;
                 for (auto node : sortedNodes[priority]) {
-                    auto const height = this->getContentHeight(node) * this->getScale(node);
+                    auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
                     priorityHeight += height;
                 }
                 // remainingHeight stores unscaled remaining height
@@ -405,7 +411,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
                 auto targetScale = (remainingHeight - difference) / remainingHeight;
                 // minScales are sorted in a decreasing priority
                 for (auto node : sortedNodes[priority]) {
-                    auto const height = this->getContentHeight(node) * this->getScale(node);
+                    auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
                     auto const minScale = this->getMinScale(node);
 
                     auto const scale = std::max(targetScale, minScale.value_or(0.f));
@@ -443,7 +449,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
                 // only partially scale up, should be the last priority to scale
                 auto priorityHeight = 0.f;
                 for (auto node : sortedNodes[priority]) {
-                    auto const height = this->getContentHeight(node) * this->getScale(node);
+                    auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
                     priorityHeight += height;
                 }
                 // remainingHeight stores unscaled remaining height
@@ -454,7 +460,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
                 auto targetScale = (remainingHeight + difference) / remainingHeight;
                 // maxScales are sorted in an increasing priority
                 for (auto node : sortedNodes[priority]) {
-                    auto const height = this->getContentHeight(node) * this->getScale(node);
+                    auto const height = this->getContentHeight(node) * this->getUncommitedScale(node);
                     auto const maxScale = this->getMaxCrossScale(layout, node);
 
                     auto const scale = std::min(targetScale, maxScale);
@@ -654,7 +660,7 @@ void SimpleAxisLayout::Impl::applyMainPositioning(CCNode* layout, std::vector<CC
         }
 
         auto const height = this->getContentHeight(node) * this->getScale(node);
-        
+
         node->ignoreAnchorPointForPosition(false);
         node->setAnchorPoint(ccp(0.5f, 0.5f));
 
@@ -724,9 +730,9 @@ void SimpleAxisLayout::Impl::apply(cocos2d::CCNode* layout) {
             // the new scale as the original scale
             m_originalScalesPerNode[child] = scale;
         }
-        else {
-            this->setScale(child, m_originalScalesPerNode[child]);
-        }
+        // else {
+        //     this->setScale(child, m_originalScalesPerNode[child]);
+        // }
         m_relativeScalesPerNode[child] = 1.f;
     }
 
@@ -737,7 +743,7 @@ void SimpleAxisLayout::Impl::apply(cocos2d::CCNode* layout) {
             m_relativeScalesPerNode[child] *= crossScales[child];
         }
 
-        this->setScale(child, m_originalScalesPerNode[child] * m_relativeScalesPerNode[child]);
+        // this->setScale(child, m_originalScalesPerNode[child] * m_relativeScalesPerNode[child]);
     }
 
     // calculate required main scaling
@@ -749,6 +755,10 @@ void SimpleAxisLayout::Impl::apply(cocos2d::CCNode* layout) {
             m_relativeScalesPerNode[child] *= mainScales[child];
         }
 
+        // this->setScale(child, m_originalScalesPerNode[child] * m_relativeScalesPerNode[child]);
+    }
+
+    for (auto child : realChildren) {
         this->setScale(child, m_originalScalesPerNode[child] * m_relativeScalesPerNode[child]);
     }
 

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -591,7 +591,7 @@ bool ModsLayer::init() {
 
     m_pageMenu = CCMenu::create();
     m_pageMenu->setID("page-menu");
-    m_pageMenu->setContentWidth(200.f);
+    m_pageMenu->setContentSize({200.f, 16.f});
     m_pageMenu->setAnchorPoint({ 1.f, 1.f });
     m_pageMenu->setScale(.65f);
 
@@ -608,9 +608,12 @@ bool ModsLayer::init() {
     m_pageMenu->addChild(m_goToPageBtn);
 
     m_pageMenu->setLayout(
-        RowLayout::create()
-            ->setAxisReverse(true)
-            ->setAxisAlignment(AxisAlignment::End)
+        SimpleRowLayout::create()
+            ->setMainAxisDirection(AxisDirection::RightToLeft)
+            ->setMainAxisAlignment(MainAxisAlignment::End)
+            ->setCrossAxisAlignment(CrossAxisAlignment::End)
+            ->setMainAxisScaling(AxisScaling::ScaleDown)
+            ->setGap(5.f)
     );
     this->addChildAtPosition(m_pageMenu, Anchor::TopRight, ccp(-5, -5), false);
 

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -501,8 +501,9 @@ bool ModsLayer::init() {
     auto mainTabs = CCMenu::create();
     mainTabs->setID("tabs-menu");
     mainTabs->setContentWidth(tabsTop->getContentWidth() - 45);
+    mainTabs->setContentHeight(32);
     mainTabs->setAnchorPoint({ .5f, .0f });
-    mainTabs->setPosition(m_frame->convertToWorldSpace(tabsTop->getPosition() + ccp(0, 8)));
+    mainTabs->setPosition(m_frame->convertToWorldSpace(tabsTop->getPosition() + ccp(0, 6)));
     // Increment touch priority so the mods in the list don't override
     mainTabs->setTouchPriority(-150);
 
@@ -522,7 +523,10 @@ bool ModsLayer::init() {
         m_tabs.push_back(btn);
     }
 
-    mainTabs->setLayout(RowLayout::create());
+    mainTabs->setLayout(
+        SimpleRowLayout::create()
+            ->setMainAxisScaling(AxisScaling::Scale)
+    );
     this->addChild(mainTabs);
 
     // Actions

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -610,9 +610,9 @@ bool ModsLayer::init() {
     m_pageMenu->setLayout(
         SimpleRowLayout::create()
             ->setMainAxisDirection(AxisDirection::RightToLeft)
-            ->setMainAxisAlignment(MainAxisAlignment::End)
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setCrossAxisAlignment(CrossAxisAlignment::End)
-            ->setMainAxisScaling(AxisScaling::ScaleDown)
+            ->setCrossAxisScaling(AxisScaling::ScaleDown)
             ->setGap(5.f)
     );
     this->addChildAtPosition(m_pageMenu, Anchor::TopRight, ccp(-5, -5), false);

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -377,6 +377,7 @@ bool ModsLayer::init() {
     backMenu->setLayout(
         SimpleRowLayout::create()
             ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setGap(5.f)
     );
     this->addChildAtPosition(backMenu, Anchor::TopLeft, ccp(12, -25), false);
 
@@ -445,12 +446,14 @@ bool ModsLayer::init() {
         SimpleColumnLayout::create()
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisDirection(AxisDirection::BottomToTop)
+            ->setGap(5.f)
     );
 
     rightActionsMenu->setLayout(
         SimpleColumnLayout::create()
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisDirection(AxisDirection::BottomToTop)
+            ->setGap(5.f)
     );
 
     // positioning based on size of mod list frame and maximum width of buttons
@@ -528,6 +531,7 @@ bool ModsLayer::init() {
     mainTabs->setLayout(
         SimpleRowLayout::create()
             ->setMainAxisScaling(AxisScaling::Scale)
+            ->setGap(5.f)
     );
     this->addChild(mainTabs);
 
@@ -535,7 +539,7 @@ bool ModsLayer::init() {
 
     auto listDisplayMenu = CCMenu::create();
     listDisplayMenu->setID("list-actions-menu");
-    listDisplayMenu->setContentHeight(100);
+    listDisplayMenu->setContentSize({30, 100});
     listDisplayMenu->setAnchorPoint({ 1, 0 });
     listDisplayMenu->setScale(.65f);
 
@@ -573,7 +577,12 @@ bool ModsLayer::init() {
     // searchBtn->setID("search-button");
     // listDisplayMenu->addChild(searchBtn);
 
-    listDisplayMenu->setLayout(ColumnLayout::create()->setAxisReverse(true));
+    listDisplayMenu->setLayout(
+        SimpleColumnLayout::create()
+            ->setMainAxisDirection(AxisDirection::TopToBottom)
+            ->setMainAxisScaling(AxisScaling::Scale)
+            ->setGap(2.f)
+    );
     m_frame->addChildAtPosition(listDisplayMenu, Anchor::Left, ccp(-5, 25));
 
     m_statusNode = ModsStatusNode::create();

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -382,12 +382,12 @@ bool ModsLayer::init() {
 
     auto actionsMenu = CCMenu::create();
     actionsMenu->setID("actions-menu");
-    actionsMenu->setContentHeight(200.f);
+    actionsMenu->setContentSize({38.f, 200.f});
     actionsMenu->setAnchorPoint({ .5f, .0f });
 
     auto rightActionsMenu = CCMenu::create();
     rightActionsMenu->setID("right-actions-menu");
-    rightActionsMenu->setContentHeight(200.0f);
+    rightActionsMenu->setContentSize({38.f, 200.f});
     rightActionsMenu->setAnchorPoint({ .5f, .0f });
 
     auto reloadSpr = createGeodeCircleButton(
@@ -442,13 +442,15 @@ bool ModsLayer::init() {
     actionsMenu->addChild(addBtn);
 
     actionsMenu->setLayout(
-        ColumnLayout::create()
-            ->setAxisAlignment(AxisAlignment::Start)
+        SimpleColumnLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setMainAxisDirection(AxisDirection::BottomToTop)
     );
 
     rightActionsMenu->setLayout(
-        ColumnLayout::create()
-            ->setAxisAlignment(AxisAlignment::Start)
+        SimpleColumnLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setMainAxisDirection(AxisDirection::BottomToTop)
     );
 
     // positioning based on size of mod list frame and maximum width of buttons

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -10,6 +10,7 @@
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/utils/ranges.hpp>
 #include <Geode/ui/GeodeUI.hpp>
+#include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/binding/Slider.hpp>
 #include <Geode/binding/SetTextPopup.hpp>
 #include <Geode/binding/SetIDPopup.hpp>

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -364,7 +364,7 @@ bool ModsLayer::init() {
 
     auto backMenu = CCMenu::create();
     backMenu->setID("back-menu");
-    backMenu->setContentWidth(100.f);
+    backMenu->setContentSize({100.f, 40.f});
     backMenu->setAnchorPoint({ .0f, .5f });
     
     auto backSpr = CCSprite::createWithSpriteFrameName("GJ_arrow_03_001.png");
@@ -375,8 +375,8 @@ bool ModsLayer::init() {
     backMenu->addChild(backBtn);
 
     backMenu->setLayout(
-        RowLayout::create()
-            ->setAxisAlignment(AxisAlignment::Start)
+        SimpleRowLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
     );
     this->addChildAtPosition(backMenu, Anchor::TopLeft, ccp(12, -25), false);
 
@@ -501,7 +501,7 @@ bool ModsLayer::init() {
     auto mainTabs = CCMenu::create();
     mainTabs->setID("tabs-menu");
     mainTabs->setContentWidth(tabsTop->getContentWidth() - 45);
-    mainTabs->setContentHeight(32);
+    mainTabs->setContentHeight(32.f);
     mainTabs->setAnchorPoint({ .5f, .0f });
     mainTabs->setPosition(m_frame->convertToWorldSpace(tabsTop->getPosition() + ccp(0, 6)));
     // Increment touch priority so the mods in the list don't override

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -446,14 +446,14 @@ bool ModsLayer::init() {
         SimpleColumnLayout::create()
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisDirection(AxisDirection::BottomToTop)
-            ->setGap(5.f)
+            ->setGap(2.f)
     );
 
     rightActionsMenu->setLayout(
         SimpleColumnLayout::create()
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisDirection(AxisDirection::BottomToTop)
-            ->setGap(5.f)
+            ->setGap(2.f)
     );
 
     // positioning based on size of mod list frame and maximum width of buttons

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -60,7 +60,7 @@ bool ModsStatusNode::init() {
     m_btnMenu = CCMenu::create();
     m_btnMenu->setID("button-menu");
     m_btnMenu->setContentWidth(m_obContentSize.width);
-
+    m_btnMenu->setContentHeight(25.f);
     auto restartSpr = createGeodeButton("Restart Now");
     restartSpr->setScale(.65f);
     m_restartBtn = CCMenuItemSpriteExtra::create(
@@ -83,7 +83,10 @@ bool ModsStatusNode::init() {
     m_cancelBtn->setID("cancel-button");
     m_btnMenu->addChild(m_cancelBtn);
 
-    m_btnMenu->setLayout(RowLayout::create());
+    m_btnMenu->setLayout(
+        SimpleRowLayout::create()
+            ->setGap(5.f)
+    );
     m_btnMenu->getLayout()->ignoreInvisibleChildren(true);
     this->addChildAtPosition(m_btnMenu, Anchor::Center, ccp(0, 5));
 

--- a/loader/src/ui/mods/list/ModDeveloperItem.cpp
+++ b/loader/src/ui/mods/list/ModDeveloperItem.cpp
@@ -2,6 +2,7 @@
 
 #include <Geode/cocos/base_nodes/CCNode.h>
 #include <Geode/ui/Layout.hpp>
+#include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/cocos/cocoa/CCGeometry.h>
 #include <Geode/cocos/label_nodes/CCLabelBMFont.h>
 #include <Geode/cocos/platform/CCPlatformMacros.h>

--- a/loader/src/ui/mods/list/ModDeveloperItem.cpp
+++ b/loader/src/ui/mods/list/ModDeveloperItem.cpp
@@ -81,11 +81,15 @@ bool ModDeveloperItem::init(
         menu->setContentSize({size.width/2, size.height});
         menu->setScale(0.6f);
 
-        auto layout = RowLayout::create();
-        layout->setDefaultScaleLimits(0.5f, 0.7f);
-        layout->setAxisAlignment(AxisAlignment::End);
-        layout->setAxisReverse(true);
-        menu->setLayout(layout);
+        menu->setLayout(
+            SimpleRowLayout::create()
+                ->setMinRelativeScale(.65f)
+                ->setMaxRelativeScale(1.0f)
+                ->setMainAxisAlignment(MainAxisAlignment::End)
+                ->setMainAxisDirection(AxisDirection::LeftToRight)
+                ->setCrossAxisScaling(AxisScaling::Scale)
+                ->setGap(5.0f)
+        );
 
         this->addChildAtPosition(
             menu,

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -56,10 +56,11 @@ bool ModItem::init(ModSource&& source) {
 
     m_versionLabel = CCLabelBMFont::create("", "bigFont.fnt");
     m_versionLabel->setID("version-label");
+    m_versionLabel->setScale(0.7f);
     m_versionLabel->setLayoutOptions(
         SimpleAxisLayoutOptions::create()
-            ->setMinRelativeScale(.5f)
-            ->setMaxRelativeScale(.7f)
+            ->setMinRelativeScale(.6f)
+            ->setMaxRelativeScale(1.f)
         );
     m_titleContainer->addChild(m_versionLabel);
 
@@ -227,9 +228,10 @@ bool ModItem::init(ModSource&& source) {
                 m_enableToggle = CCMenuItemToggler::createWithStandardSprites(
                     this, menu_selector(ModItem::onEnable), 1.f
                 );
+                m_enableToggle->setScale(0.9f);
                 m_enableToggle->setLayoutOptions(
                     SimpleAxisLayoutOptions::create()
-                        ->setMaxRelativeScale(.9f)
+                        ->setMaxRelativeScale(1.f)
                 );
                 m_enableToggle->setID("enable-toggler");
                 // Manually handle toggle state
@@ -415,13 +417,14 @@ void ModItem::updateState() {
 
     // Download counts go next to the version like on the website on grid view
     if (m_downloadCountContainer) {
+        m_downloadCountContainer->setScale(0.7f);
         m_downloadCountContainer->removeFromParent();
         if (m_display == ModListDisplay::Grid) {
             m_titleContainer->insertAfter(m_downloadCountContainer, m_versionDownloadSeparator);
             m_downloadCountContainer->setLayoutOptions(
                 SimpleAxisLayoutOptions::create()
                     ->setMinRelativeScale(.1f)
-                    ->setMaxRelativeScale(.7f)
+                    ->setMaxRelativeScale(1.f)
                 );
         }
         else {
@@ -429,7 +432,7 @@ void ModItem::updateState() {
             m_downloadCountContainer->setLayoutOptions( 
                 SimpleAxisLayoutOptions::create()
                     ->setMinRelativeScale(.1f)
-                    ->setMaxRelativeScale(.7f)
+                    ->setMaxRelativeScale(1.f)
             );
         }
     }

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -47,12 +47,19 @@ bool ModItem::init(ModSource&& source) {
 
     m_titleLabel = CCLabelBMFont::create(m_source.getMetadata().getName().c_str(), "bigFont.fnt");
     m_titleLabel->setID("title-label");
-    m_titleLabel->setLayoutOptions(AxisLayoutOptions::create()->setScaleLimits(.3f, std::nullopt));
+    m_titleLabel->setLayoutOptions(
+        SimpleAxisLayoutOptions::create()
+            ->setMinRelativeScale(.3f)
+        );
     m_titleContainer->addChild(m_titleLabel);
 
     m_versionLabel = CCLabelBMFont::create("", "bigFont.fnt");
     m_versionLabel->setID("version-label");
-    m_versionLabel->setLayoutOptions(AxisLayoutOptions::create()->setScaleLimits(.5f, .7f)->setScalePriority(1));
+    m_versionLabel->setLayoutOptions(
+        SimpleAxisLayoutOptions::create()
+            ->setMinRelativeScale(.5f)
+            ->setMaxRelativeScale(.7f)
+        );
     m_titleContainer->addChild(m_versionLabel);
 
     m_versionDownloadSeparator = CCLabelBMFont::create("•", "bigFont.fnt");
@@ -60,9 +67,11 @@ bool ModItem::init(ModSource&& source) {
     m_titleContainer->addChild(m_versionDownloadSeparator);
     
     m_titleContainer->setLayout(
-        RowLayout::create()
-            ->setDefaultScaleLimits(.1f, 1.f)
-            ->setAxisAlignment(AxisAlignment::Start)
+        SimpleRowLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setMainAxisScaling(AxisScaling::Scale)
+            ->setCrossAxisScaling(AxisScaling::Grow)
+            ->setGap(5.f)
     );
     m_titleContainer->getLayout()->ignoreInvisibleChildren(true);
     m_infoContainer->addChildAtPosition(m_titleContainer, Anchor::Left);
@@ -401,7 +410,7 @@ void ModItem::updateState() {
             m_titleContainer->insertAfter(m_downloadCountContainer, m_versionDownloadSeparator);
             m_downloadCountContainer->setLayoutOptions(
                 SimpleAxisLayoutOptions::create()
-                    ->setMaxRelativeScale(.1f)
+                    ->setMinRelativeScale(.1f)
                     ->setMaxRelativeScale(.7f)
                 );
         }
@@ -409,7 +418,7 @@ void ModItem::updateState() {
             m_viewMenu->addChild(m_downloadCountContainer);
             m_downloadCountContainer->setLayoutOptions( 
                 SimpleAxisLayoutOptions::create()
-                    ->setMaxRelativeScale(.1f)
+                    ->setMinRelativeScale(.1f)
                     ->setMaxRelativeScale(.7f)
             );
         }
@@ -604,19 +613,20 @@ void ModItem::updateState() {
     // On grid view, m_titleContainer contains the version and download count 
     // but not the actual title lol
     m_titleContainer->setContentWidth(titleSpace.width / m_infoContainer->getScale());
+    m_titleContainer->setContentHeight(30);
     if (m_display == ModListDisplay::Grid) {
-        static_cast<RowLayout*>(m_titleContainer->getLayout())
+        static_cast<SimpleRowLayout*>(m_titleContainer->getLayout())
             ->setGap(10)
-            ->setAxisAlignment(AxisAlignment::Center);
-        static_cast<RowLayout*>(m_developers->getLayout())
-            ->setAxisAlignment(AxisAlignment::Center);
+            ->setMainAxisAlignment(MainAxisAlignment::Center);
+        static_cast<SimpleRowLayout*>(m_developers->getLayout())
+            ->setMainAxisAlignment(MainAxisAlignment::Center);
     }
     else {
-        static_cast<RowLayout*>(m_titleContainer->getLayout())
+        static_cast<SimpleRowLayout*>(m_titleContainer->getLayout())
             ->setGap(5)
-            ->setAxisAlignment(AxisAlignment::Start);
-        static_cast<RowLayout*>(m_developers->getLayout())
-            ->setAxisAlignment(AxisAlignment::Start);
+            ->setMainAxisAlignment(MainAxisAlignment::Start);
+        static_cast<SimpleRowLayout*>(m_developers->getLayout())
+            ->setMainAxisAlignment(MainAxisAlignment::Start);
     }
     m_titleContainer->updateLayout();
     m_developers->setContentWidth(titleSpace.width / m_infoContainer->getScale());

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -91,8 +91,9 @@ bool ModItem::init(ModSource&& source) {
     m_developers->addChild(developersBtn);
 
     m_developers->setLayout(
-        RowLayout::create()
-            ->setAxisAlignment(AxisAlignment::Start)
+        SimpleRowLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setGap(5.f)
     );
     m_infoContainer->addChildAtPosition(m_developers, Anchor::Left);
 
@@ -613,7 +614,7 @@ void ModItem::updateState() {
     // On grid view, m_titleContainer contains the version and download count 
     // but not the actual title lol
     m_titleContainer->setContentWidth(titleSpace.width / m_infoContainer->getScale());
-    m_titleContainer->setContentHeight(30);
+    m_titleContainer->setContentHeight(30.f);
     if (m_display == ModListDisplay::Grid) {
         static_cast<SimpleRowLayout*>(m_titleContainer->getLayout())
             ->setGap(10)
@@ -630,6 +631,7 @@ void ModItem::updateState() {
     }
     m_titleContainer->updateLayout();
     m_developers->setContentWidth(titleSpace.width / m_infoContainer->getScale());
+    m_developers->setContentHeight(30.f);
     m_developers->updateLayout();
 
     if (m_recommendedBy) {

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -50,6 +50,7 @@ bool ModItem::init(ModSource&& source) {
     m_titleLabel->setLayoutOptions(
         SimpleAxisLayoutOptions::create()
             ->setMinRelativeScale(.3f)
+            ->setMaxRelativeScale(1.f)
         );
     m_titleContainer->addChild(m_titleLabel);
 
@@ -221,6 +222,10 @@ bool ModItem::init(ModSource&& source) {
             if (!mod->isInternal()) {
                 m_enableToggle = CCMenuItemToggler::createWithStandardSprites(
                     this, menu_selector(ModItem::onEnable), 1.f
+                );
+                m_enableToggle->setLayoutOptions(
+                    SimpleAxisLayoutOptions::create()
+                        ->setMaxRelativeScale(.9f)
                 );
                 m_enableToggle->setID("enable-toggler");
                 // Manually handle toggle state
@@ -665,7 +670,7 @@ void ModItem::updateState() {
         default:
         case ModListDisplay::SmallList: {
             m_infoContainer->updateAnchoredPosition(Anchor::Left, ccp(m_obContentSize.height + 10, 0), ccp(0, .5f));
-            m_titleContainer->updateAnchoredPosition(Anchor::TopLeft, ccp(0, 0), ccp(0, 1));
+            m_titleContainer->updateAnchoredPosition(Anchor::TopLeft, ccp(0, 2), ccp(0, 1));
 
             // m_description is hidden
             m_developers->updateAnchoredPosition(Anchor::BottomLeft, ccp(0, 3), ccp(0, 0));

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -190,9 +190,11 @@ bool ModItem::init(ModSource&& source) {
     m_viewMenu->addChild(viewBtn);
 
     m_viewMenu->setLayout(
-        RowLayout::create()
-            ->setAxisReverse(true)
-            ->setAxisAlignment(AxisAlignment::End)
+        SimpleRowLayout::create()
+            ->setMainAxisDirection(AxisDirection::RightToLeft)
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setMainAxisScaling(AxisScaling::Scale)
+            ->setCrossAxisScaling(AxisScaling::Scale)
             ->setGap(10)
     );
     m_viewMenu->getLayout()->ignoreInvisibleChildren(true);
@@ -397,14 +399,22 @@ void ModItem::updateState() {
         m_downloadCountContainer->removeFromParent();
         if (m_display == ModListDisplay::Grid) {
             m_titleContainer->insertAfter(m_downloadCountContainer, m_versionDownloadSeparator);
-            m_downloadCountContainer->setLayoutOptions(AxisLayoutOptions::create()->setScaleLimits(.1f, .7f));
+            m_downloadCountContainer->setLayoutOptions(
+                SimpleAxisLayoutOptions::create()
+                    ->setMaxRelativeScale(.1f)
+                    ->setMaxRelativeScale(.7f)
+                );
         }
         else {
             m_viewMenu->addChild(m_downloadCountContainer);
-            m_downloadCountContainer->setLayoutOptions(AxisLayoutOptions::create()->setScaleLimits(.1f, .6f));
+            m_downloadCountContainer->setLayoutOptions( 
+                SimpleAxisLayoutOptions::create()
+                    ->setMaxRelativeScale(.1f)
+                    ->setMaxRelativeScale(.7f)
+            );
         }
     }
-
+    
     // Move badges to either be next to the title or in the top left corner in grid view
     if (m_badgeContainer) {
         m_badgeContainer->removeFromParent();
@@ -678,17 +688,19 @@ void ModItem::updateState() {
     m_infoContainer->updateLayout();
     
     // Update button menu state
+    m_viewMenu->setContentHeight(40.f);
+
     if (m_display == ModListDisplay::Grid) {
         m_viewMenu->setContentWidth(m_obContentSize.width / m_viewMenu->getScaleX());
         m_viewMenu->updateAnchoredPosition(Anchor::Bottom, ccp(0, 5), ccp(.5f, 0));
         m_viewMenu->setScale(.45f);
-        static_cast<RowLayout*>(m_viewMenu->getLayout())->setAxisAlignment(AxisAlignment::Center);
+        static_cast<SimpleRowLayout*>(m_viewMenu->getLayout())->setMainAxisAlignment(MainAxisAlignment::Center);
     }
     else {
         m_viewMenu->setContentWidth(m_obContentSize.width / m_viewMenu->getScaleX() / 2 - 20);
         m_viewMenu->updateAnchoredPosition(Anchor::Right, ccp(-10, 0), ccp(1, .5f));
         m_viewMenu->setScale(.55f);
-        static_cast<RowLayout*>(m_viewMenu->getLayout())->setAxisAlignment(AxisAlignment::End);
+        static_cast<SimpleRowLayout*>(m_viewMenu->getLayout())->setMainAxisAlignment(MainAxisAlignment::Start);
     }
     m_viewMenu->updateLayout();
 

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -202,7 +202,7 @@ bool ModItem::init(ModSource&& source) {
             ->setMainAxisDirection(AxisDirection::RightToLeft)
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisScaling(AxisScaling::Scale)
-            ->setCrossAxisScaling(AxisScaling::Grow)
+            ->setCrossAxisScaling(AxisScaling::Scale)
             ->setMinRelativeScale(1.f)
             ->setGap(10)
     );

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -487,7 +487,7 @@ void ModItem::updateState() {
 
     auto titleSpace = m_display == ModListDisplay::Grid ?
         CCSize(m_obContentSize.width - 10, 35) :
-        CCSize(m_obContentSize.width / 2 - m_obContentSize.height, m_obContentSize.height - 5);
+        CCSize(m_obContentSize.width / 1.75 - m_obContentSize.height, m_obContentSize.height - 5);
 
     // Divide by scale of info container since that actually determines the size
     // (Since the scale of m_titleContainer and m_developers is managed by its layout)

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -433,15 +433,18 @@ void ModItem::updateState() {
     if (m_badgeContainer) {
         m_badgeContainer->removeFromParent();
         if (m_display == ModListDisplay::Grid) {
-            m_badgeContainer->setScale(.3f);
+            m_badgeContainer->setScale(.35f);
+            m_badgeContainer->setContentWidth(30.f);
             m_badgeContainer->setLayout(
-                ColumnLayout::create()
-                    ->setAxisReverse(true)
-                    ->setAutoGrowAxis(true)
-                    ->setAxisAlignment(AxisAlignment::Start)
+                SimpleColumnLayout::create()
+                    ->setMainAxisAlignment(MainAxisAlignment::Start)
+                    ->setMainAxisDirection(AxisDirection::TopToBottom)
+                    ->setMainAxisScaling(AxisScaling::Fit)
+                    ->setCrossAxisScaling(AxisScaling::Scale)
+                    ->setGap(5.f)
             );
             m_badgeContainer->getLayout()->ignoreInvisibleChildren(true);
-            this->addChildAtPosition(m_badgeContainer, Anchor::TopLeft, ccp(5, -2), ccp(0, 1));
+            this->addChildAtPosition(m_badgeContainer, Anchor::TopLeft, ccp(4, -4), ccp(0, 1));
         }
         else {
             m_badgeContainer->setContentHeight(30.f);

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <Geode/ui/GeodeUI.hpp>
+#include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/loader/Event.hpp>

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -68,7 +68,7 @@ bool ModItem::init(ModSource&& source) {
         SimpleRowLayout::create()
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisScaling(AxisScaling::Scale)
-            ->setCrossAxisScaling(AxisScaling::Grow)
+            ->setCrossAxisScaling(AxisScaling::ScaleDownGaps)
             ->setGap(5.f)
     );
     m_titleContainer->getLayout()->ignoreInvisibleChildren(true);
@@ -626,6 +626,7 @@ void ModItem::updateState() {
     // Update size and direction of title
     // On grid view, m_titleContainer contains the version and download count 
     // but not the actual title lol
+    m_titleLabel->setScale(1.f);
     m_titleContainer->setContentHeight(30.f);
     m_titleContainer->setContentWidth(titleSpace.width / m_infoContainer->getScale());
     if (m_display == ModListDisplay::Grid) {

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -274,11 +274,7 @@ bool ModItem::init(ModSource&& source) {
             // Only show default Modtober tag if not a winner
             else if (metadata.tags.contains("modtober24")) {
                 auto shortVer = CCSprite::createWithSpriteFrameName("tag-modtober.png"_spr);
-                shortVer->setTag(1);
                 m_badgeContainer->addChild(shortVer);
-                auto longVer = CCSprite::createWithSpriteFrameName("tag-modtober-long.png"_spr);
-                longVer->setTag(2);
-                m_badgeContainer->addChild(longVer);
             }
 
             // Show mod download count here already so people can make informed decisions 

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -47,11 +47,6 @@ bool ModItem::init(ModSource&& source) {
 
     m_titleLabel = CCLabelBMFont::create(m_source.getMetadata().getName().c_str(), "bigFont.fnt");
     m_titleLabel->setID("title-label");
-    m_titleLabel->setLayoutOptions(
-        SimpleAxisLayoutOptions::create()
-            ->setMinRelativeScale(.3f)
-            ->setMaxRelativeScale(1.f)
-        );
     m_titleContainer->addChild(m_titleLabel);
 
     m_versionLabel = CCLabelBMFont::create("", "bigFont.fnt");
@@ -59,7 +54,7 @@ bool ModItem::init(ModSource&& source) {
     m_versionLabel->setScale(0.7f);
     m_versionLabel->setLayoutOptions(
         SimpleAxisLayoutOptions::create()
-            ->setMinRelativeScale(.6f)
+            ->setMinRelativeScale(.7f)
             ->setMaxRelativeScale(1.f)
         );
     m_titleContainer->addChild(m_versionLabel);
@@ -206,7 +201,8 @@ bool ModItem::init(ModSource&& source) {
             ->setMainAxisDirection(AxisDirection::RightToLeft)
             ->setMainAxisAlignment(MainAxisAlignment::Start)
             ->setMainAxisScaling(AxisScaling::Scale)
-            ->setCrossAxisScaling(AxisScaling::Scale)
+            ->setCrossAxisScaling(AxisScaling::Grow)
+            ->setMinRelativeScale(1.f)
             ->setGap(10)
     );
     m_viewMenu->getLayout()->ignoreInvisibleChildren(true);
@@ -216,8 +212,8 @@ bool ModItem::init(ModSource&& source) {
     m_badgeContainer->setID("badge-container");
     m_badgeContainer->setLayoutOptions(
         SimpleAxisLayoutOptions::create()
-            ->setMinRelativeScale(1.2f)
-            ->setMaxRelativeScale(1.5f)
+            ->setMinRelativeScale(.8f)
+            ->setMaxRelativeScale(1.f)
     );
 
     // Handle source-specific stuff
@@ -417,7 +413,7 @@ void ModItem::updateState() {
 
     // Download counts go next to the version like on the website on grid view
     if (m_downloadCountContainer) {
-        m_downloadCountContainer->setScale(0.7f);
+        m_downloadCountContainer->setScale(0.6f);
         m_downloadCountContainer->removeFromParent();
         if (m_display == ModListDisplay::Grid) {
             m_titleContainer->insertAfter(m_downloadCountContainer, m_versionDownloadSeparator);
@@ -441,6 +437,7 @@ void ModItem::updateState() {
     if (m_badgeContainer) {
         m_badgeContainer->removeFromParent();
         if (m_display == ModListDisplay::Grid) {
+            m_badgeContainer->setScale(.3f);
             m_badgeContainer->setLayout(
                 ColumnLayout::create()
                     ->setAxisReverse(true)
@@ -448,10 +445,11 @@ void ModItem::updateState() {
                     ->setAxisAlignment(AxisAlignment::Start)
             );
             m_badgeContainer->getLayout()->ignoreInvisibleChildren(true);
-            m_badgeContainer->setScale(.3f);
             this->addChildAtPosition(m_badgeContainer, Anchor::TopLeft, ccp(5, -2), ccp(0, 1));
         }
         else {
+            m_badgeContainer->setContentHeight(30.f);
+            m_badgeContainer->setScale(1.f);
             m_badgeContainer->setLayout(
                 SimpleRowLayout::create()
                     ->setMainAxisAlignment(MainAxisAlignment::Start)
@@ -628,6 +626,7 @@ void ModItem::updateState() {
     // Update size and direction of title
     // On grid view, m_titleContainer contains the version and download count 
     // but not the actual title lol
+    m_titleContainer->setContentHeight(30.f);
     m_titleContainer->setContentWidth(titleSpace.width / m_infoContainer->getScale());
     if (m_display == ModListDisplay::Grid) {
         static_cast<SimpleRowLayout*>(m_titleContainer->getLayout())
@@ -655,8 +654,6 @@ void ModItem::updateState() {
     limitNodeWidth(m_downloadWaiting, m_titleContainer->getContentWidth(), 1.f, .1f);
     limitNodeWidth(m_downloadBarContainer, m_titleContainer->getContentWidth(), 1.f, .1f);
 
-    // reset options before updating
-    m_titleLabel->setLayoutOptions(nullptr);
     // Update positioning (jesus)
     switch (m_display) {
         case ModListDisplay::Grid: {
@@ -683,7 +680,11 @@ void ModItem::updateState() {
         case ModListDisplay::SmallList: {
             m_infoContainer->updateAnchoredPosition(Anchor::Left, ccp(m_obContentSize.height + 10, 0), ccp(0, .5f));
             m_titleContainer->updateAnchoredPosition(Anchor::TopLeft, ccp(0, 2), ccp(0, 1));
-
+            m_titleLabel->setLayoutOptions(
+                SimpleAxisLayoutOptions::create()
+                    ->setMinRelativeScale(.4f)
+                    ->setMaxRelativeScale(1.f)
+                );
             // m_description is hidden
             m_developers->updateAnchoredPosition(Anchor::BottomLeft, ccp(0, 3), ccp(0, 0));
             m_restartRequiredLabel->updateAnchoredPosition(Anchor::BottomLeft, ccp(0, 3), ccp(0, 0));
@@ -699,7 +700,11 @@ void ModItem::updateState() {
         case ModListDisplay::BigList: {
             m_infoContainer->updateAnchoredPosition(Anchor::Left, ccp(m_obContentSize.height + 10, 0), ccp(0, .5f));
             m_titleContainer->updateAnchoredPosition(Anchor::TopLeft, ccp(0, 0), ccp(0, 1));
-
+            m_titleLabel->setLayoutOptions(
+                SimpleAxisLayoutOptions::create()
+                    ->setMinRelativeScale(.4f)
+                    ->setMaxRelativeScale(1.f)
+                );
             m_developers->updateAnchoredPosition(Anchor::Left, ccp(0, 0), ccp(0, .5f));
 
             m_description->updateAnchoredPosition(Anchor::BottomLeft, ccp(0, 0), ccp(0, 0));

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -678,7 +678,7 @@ void ModItem::updateState() {
             m_titleContainer->updateAnchoredPosition(Anchor::TopLeft, ccp(0, 2), ccp(0, 1));
             m_titleLabel->setLayoutOptions(
                 SimpleAxisLayoutOptions::create()
-                    ->setMinRelativeScale(.4f)
+                    ->setMinRelativeScale(.5f)
                     ->setMaxRelativeScale(1.f)
                 );
             // m_description is hidden
@@ -698,7 +698,7 @@ void ModItem::updateState() {
             m_titleContainer->updateAnchoredPosition(Anchor::TopLeft, ccp(0, 0), ccp(0, 1));
             m_titleLabel->setLayoutOptions(
                 SimpleAxisLayoutOptions::create()
-                    ->setMinRelativeScale(.4f)
+                    ->setMinRelativeScale(.5f)
                     ->setMaxRelativeScale(1.f)
                 );
             m_developers->updateAnchoredPosition(Anchor::Left, ccp(0, 0), ccp(0, .5f));

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -212,7 +212,7 @@ bool ModItem::init(ModSource&& source) {
     m_badgeContainer->setID("badge-container");
     m_badgeContainer->setLayoutOptions(
         SimpleAxisLayoutOptions::create()
-            ->setMinRelativeScale(.8f)
+            ->setMinRelativeScale(.6f)
             ->setMaxRelativeScale(1.f)
     );
 
@@ -453,7 +453,7 @@ void ModItem::updateState() {
             m_badgeContainer->setLayout(
                 SimpleRowLayout::create()
                     ->setMainAxisAlignment(MainAxisAlignment::Start)
-                    ->setMainAxisScaling(AxisScaling::Grow)
+                    ->setMainAxisScaling(AxisScaling::Fit)
                     ->setCrossAxisScaling(AxisScaling::Scale)
                     ->setGap(5.f)
             );

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -226,7 +226,7 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
 
     auto searchFiltersMenu = CCMenu::create();
     searchFiltersMenu->setID("search-filters-menu");
-    searchFiltersMenu->setContentWidth(size.width - m_searchInput->getScaledContentWidth() - 5);
+    searchFiltersMenu->setContentSize({size.width - m_searchInput->getScaledContentWidth() - 5, 30});
     searchFiltersMenu->setAnchorPoint({ 1, .5f });
     searchFiltersMenu->setScale(.75f);
     // Set higher prio to not let list items override touch
@@ -261,8 +261,10 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
     searchFiltersMenu->addChild(m_clearFiltersBtn);
 
     searchFiltersMenu->setLayout(
-        RowLayout::create()
-            ->setAxisAlignment(AxisAlignment::End)
+        SimpleRowLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::End)
+            ->setMainAxisScaling(AxisScaling::Scale)
+            ->setGap(5.f)
     );
     m_searchMenu->addChildAtPosition(searchFiltersMenu, Anchor::Right, ccp(-10, 0));
 

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -116,9 +116,10 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
         m_updateAllMenu->setLayout(
             SimpleRowLayout::create()
                 ->setMainAxisAlignment(MainAxisAlignment::End)
-                ->setMinRelativeScale(.1f)
-                ->setMaxRelativeScale(.6f)
+                ->setMinRelativeScale(.5f)
+                ->setMaxRelativeScale(1.f)
                 ->setGap(5)
+                ->setMainAxisScaling(AxisScaling::Grow)
                 ->setCrossAxisScaling(AxisScaling::Scale)
         );
         m_updateAllMenu->getLayout()->ignoreInvisibleChildren(true);
@@ -174,9 +175,10 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
             errorsMenu->setLayout(
                 SimpleRowLayout::create()
                     ->setMainAxisAlignment(MainAxisAlignment::End)
-                    ->setMinRelativeScale(.1f)
-                    ->setMaxRelativeScale(.6f)
+                    ->setMinRelativeScale(.5f)
+                    ->setMaxRelativeScale(1.f)
                     ->setGap(5)
+                    ->setMainAxisScaling(AxisScaling::Grow)
                     ->setCrossAxisScaling(AxisScaling::Scale)
             );
             m_errorsContainer->addChildAtPosition(errorsMenu, Anchor::Right, ccp(-10, 0));

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -570,6 +570,9 @@ void ModList::updateDisplay(ModListDisplay display) {
         m_list->m_contentLayer->getPositionY() / oldPositionArea : 
         -1.f;
 
+    // fix initial width being 0
+    m_list->m_contentLayer->setContentWidth(m_list->getContentWidth());
+    
     // Update the list layout based on the display model
     if (display == ModListDisplay::Grid) {
         m_list->m_contentLayer->setLayout(
@@ -581,10 +584,10 @@ void ModList::updateDisplay(ModListDisplay display) {
     }
     else {
         m_list->m_contentLayer->setLayout(
-            ColumnLayout::create()
-                ->setAxisReverse(true)
-                ->setAxisAlignment(AxisAlignment::End)
-                ->setAutoGrowAxis(m_obContentSize.height)
+            SimpleColumnLayout::create()
+                ->setMainAxisDirection(AxisDirection::TopToBottom)
+                ->setMainAxisAlignment(MainAxisAlignment::End)
+                ->setMainAxisScaling(AxisScaling::Fit)
                 ->setGap(2.5f)
         );
     }

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -360,8 +360,9 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
     m_statusContainer->addChild(m_statusLoadingBar);
 
     m_statusContainer->setLayout(
-        ColumnLayout::create()
-            ->setAxisReverse(true)
+        SimpleColumnLayout::create()
+            ->setMainAxisDirection(AxisDirection::TopToBottom)
+            ->setGap(5.f)
     );
     m_statusContainer->getLayout()->ignoreInvisibleChildren(true);
     this->addChildAtPosition(m_statusContainer, Anchor::Center);

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -296,9 +296,9 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
     pageLeftMenu->addChild(m_pagePrevBtn);
 
     pageLeftMenu->setLayout(
-        RowLayout::create()
-            ->setAxisAlignment(AxisAlignment::End)
-            ->setAxisReverse(true)
+        SimpleRowLayout::create()
+            ->setMainAxisAlignment(MainAxisAlignment::End)
+            ->setMainAxisDirection(AxisDirection::RightToLeft)
     );
     this->addChildAtPosition(pageLeftMenu, Anchor::Left, ccp(-20, 0));
 
@@ -318,8 +318,8 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
     pageRightMenu->addChild(m_pageNextBtn);
 
     pageRightMenu->setLayout(
-        RowLayout::create()
-            ->setAxisAlignment(AxisAlignment::Start)
+        SimpleRowLayout::create()
+        ->setMainAxisAlignment(MainAxisAlignment::Start)
     );
     this->addChildAtPosition(pageRightMenu, Anchor::Right, ccp(20, 0));
 

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -171,9 +171,12 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
             errorsMenu->addChild(m_toggleErrorsOnlyBtn);
 
             errorsMenu->setLayout(
-                RowLayout::create()
-                    ->setAxisAlignment(AxisAlignment::End)
-                    ->setDefaultScaleLimits(.1f, .6f)
+                SimpleRowLayout::create()
+                    ->setMainAxisAlignment(MainAxisAlignment::End)
+                    ->setMinRelativeScale(.1f)
+                    ->setMaxRelativeScale(.6f)
+                    ->setGap(5)
+                    ->setCrossAxisScaling(AxisScaling::Scale)
             );
             m_errorsContainer->addChildAtPosition(errorsMenu, Anchor::Right, ccp(-10, 0));
 

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -81,7 +81,7 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
         
         m_updateAllMenu = CCMenu::create();
         m_updateAllMenu->setID("update-all-menu");
-        m_updateAllMenu->setContentWidth(size.width / 2);
+        m_updateAllMenu->setContentSize({size.width / 2, 21});
         m_updateAllMenu->setAnchorPoint({ 1, .5f });
 
         m_showUpdatesSpr = createGeodeButton(
@@ -113,9 +113,12 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
         m_updateAllMenu->addChild(m_updateAllLoadingCircle);
 
         m_updateAllMenu->setLayout(
-            RowLayout::create()
-                ->setAxisAlignment(AxisAlignment::End)
-                ->setDefaultScaleLimits(.1f, .6f)
+            SimpleRowLayout::create()
+                ->setMainAxisAlignment(MainAxisAlignment::End)
+                ->setMinRelativeScale(.1f)
+                ->setMaxRelativeScale(.6f)
+                ->setGap(5)
+                ->setCrossAxisScaling(AxisScaling::Scale)
         );
         m_updateAllMenu->getLayout()->ignoreInvisibleChildren(true);
         m_updateAllContainer->addChildAtPosition(m_updateAllMenu, Anchor::Right, ccp(-10, 0));

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -2,6 +2,7 @@
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/ui/GeodeUI.hpp>
 #include <Geode/ui/TextInput.hpp>
+#include <Geode/ui/SimpleAxisLayout.hpp>
 #include "../popups/FiltersPopup.hpp"
 #include "../popups/SortPopup.hpp"
 #include "../GeodeStyle.hpp"

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -82,7 +82,7 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
         
         m_updateAllMenu = CCMenu::create();
         m_updateAllMenu->setID("update-all-menu");
-        m_updateAllMenu->setContentSize({size.width / 2, 21});
+        m_updateAllMenu->setContentSize({size.width / 2, 20});
         m_updateAllMenu->setAnchorPoint({ 1, .5f });
 
         m_showUpdatesSpr = createGeodeButton(
@@ -119,8 +119,8 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
                 ->setMinRelativeScale(.5f)
                 ->setMaxRelativeScale(1.f)
                 ->setGap(5)
-                ->setMainAxisScaling(AxisScaling::Grow)
-                ->setCrossAxisScaling(AxisScaling::Scale)
+                ->setMainAxisScaling(AxisScaling::Scale)
+                ->setCrossAxisScaling(AxisScaling::ScaleDownGaps)
         );
         m_updateAllMenu->getLayout()->ignoreInvisibleChildren(true);
         m_updateAllContainer->addChildAtPosition(m_updateAllMenu, Anchor::Right, ccp(-10, 0));
@@ -154,7 +154,7 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
             
             auto errorsMenu = CCMenu::create();
             errorsMenu->setID("errors-menu");
-            errorsMenu->setContentWidth(size.width / 2);
+            errorsMenu->setContentSize({size.width / 2, 20});
             errorsMenu->setAnchorPoint({ 1, .5f });
 
             auto showErrorsSpr = createGeodeButton(
@@ -178,8 +178,8 @@ bool ModList::init(ModListSource* src, CCSize const& size) {
                     ->setMinRelativeScale(.5f)
                     ->setMaxRelativeScale(1.f)
                     ->setGap(5)
-                    ->setMainAxisScaling(AxisScaling::Grow)
-                    ->setCrossAxisScaling(AxisScaling::Scale)
+                    ->setMainAxisScaling(AxisScaling::Scale)
+                    ->setCrossAxisScaling(AxisScaling::ScaleDownGaps)
             );
             m_errorsContainer->addChildAtPosition(errorsMenu, Anchor::Right, ccp(-10, 0));
 

--- a/loader/src/ui/mods/list/ModProblemList.cpp
+++ b/loader/src/ui/mods/list/ModProblemList.cpp
@@ -37,10 +37,10 @@ bool ModProblemList::init(
     // mfw fod created a scrolllayer with layouts
     m_list = ScrollLayer::create({ size.width - 10.f, size.height - 10.f });
     m_list->m_contentLayer->setLayout(
-        ColumnLayout::create()
-            ->setAxisReverse(true)
-            ->setAxisAlignment(AxisAlignment::End)
-            ->setAutoGrowAxis(size.height)
+        SimpleColumnLayout::create()
+            ->setMainAxisDirection(AxisDirection::TopToBottom)
+            ->setMainAxisAlignment(MainAxisAlignment::Start)
+            ->setMainAxisScaling(AxisScaling::Grow)
             ->setGap(5.0f)
     );
     this->addChildAtPosition(

--- a/loader/src/ui/mods/list/ModProblemList.cpp
+++ b/loader/src/ui/mods/list/ModProblemList.cpp
@@ -2,6 +2,7 @@
 
 #include <Geode/cocos/base_nodes/CCNode.h>
 #include <Geode/ui/Layout.hpp>
+#include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/cocos/cocoa/CCGeometry.h>
 #include <Geode/cocos/platform/CCPlatformMacros.h>
 #include <Geode/utils/cocos.hpp>


### PR DESCRIPTION
- Switch most AxisLayouts to SimpleAxisLayouts, excluding a few that may need a better alternative
- Clean up some node positioning and sizing
- Use only short modtober badge to remedy some scaling issues. 

These changes also slightly improve the performance of the UI, as AxisLayouts are expensive when updating. 