### PR TITLE
linux installer fixes

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -67,9 +67,7 @@ find_gd_installation() {
         local PATH_TEST="$GD_IDX/steamapps/common/Geometry Dash"
         verbose_log "- Testing path ${YELLOW}$PATH_TEST${NC}"
 
-        is_valid_gd_path "$PATH_TEST"
-
-        if [ 0 -eq $? ]; then
+        if is_valid_gd_path "$PATH_TEST"; then
             # Found it!
             GD_PATH="$PATH_TEST"
             verbose_log "* Found at ${YELLOW}$GD_PATH${NC}"
@@ -78,8 +76,7 @@ find_gd_installation() {
     done
 
     # Check some other random paths, maybe we find something
-    is_valid_gd_path "$HOME/Games/Geometry Dash"
-    if [ 0 -eq $? ]; then
+    if is_valid_gd_path "$HOME/Games/Geometry Dash"; then
         GD_PATH="$HOME/Games/Geometry Dash"
         return 0
     fi
@@ -102,12 +99,9 @@ ask_gd_path() {
     local POTENTIAL_PATH=""
     while read -p "Enter the path where GeometryDash.exe is located: " POTENTIAL_PATH < /dev/tty; do
         local POTENTIAL_PATH=${POTENTIAL_PATH%"/GeometryDash.exe"}
-        is_valid_gd_path "$POTENTIAL_PATH"
 
-        if [ $? -eq 0 ]; then
-            confirm "Do you want to install ${YELLOW}Geode${NC} to ${YELLOW}$POTENTIAL_PATH${NC}?"
-
-            if [ $? -eq 0 ]; then
+        if is_valid_gd_path "$POTENTIAL_PATH"; then
+            if confirm "Do you want to install ${YELLOW}Geode${NC} to ${YELLOW}$POTENTIAL_PATH${NC}?"; then
                 GD_PATH="$POTENTIAL_PATH"
                 break
             fi
@@ -135,15 +129,14 @@ install() {
 
     echo ""
     echo "Downloading Geode $TAG..."
-    curl -L -o "$TEMP_DIR/geode.zip" "https://github.com/geode-sdk/geode/releases/download/$TAG/geode-$TAG-win.zip" 
-    if [ ! 0 -eq $? ]; then
+    if ! curl -L -o "$TEMP_DIR/geode.zip" "https://github.com/geode-sdk/geode/releases/download/$TAG/geode-$TAG-win.zip"; then
         echo -e "${RED}Error:${NC} Failed to download Geode." >&2
         exit 1
     fi
 
     echo "Unzipping..."
-    unzip -qq "$TEMP_DIR/geode.zip" -d "$TEMP_DIR/geode"
-    if [ ! 0 -eq $? ]; then
+
+    if ! unzip -qq "$TEMP_DIR/geode.zip" -d "$TEMP_DIR/geode"; then
         echo -e "${RED}Error:${NC} Failed to unzip Geode." >&2
         exit 1
     fi
@@ -184,16 +177,14 @@ fi
 
 echo -e "Detected latest ${YELLOW}Geode${NC} version as ${BLUE}$TAG${NC}."
 
-find_gd_installation
-if [ ! $? -eq 0 ]; then
+if ! find_gd_installation; then
     echo -e "Didn't find ${YELLOW}Geometry Dash${NC} in any of the commonly used paths."
 
     ask_gd_path
 else
     echo -e "Found Geometry Dash at ${YELLOW}$GD_PATH${NC}."
-    confirm "Do you want to install ${YELLOW}Geode${NC} to ${YELLOW}$GD_PATH${NC}?"
 
-    if [ ! $? -eq 0 ]; then
+    if ! confirm "Do you want to install ${YELLOW}Geode${NC} to ${YELLOW}$GD_PATH${NC}?"; then
         ask_gd_path
     fi
 fi

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -41,18 +41,18 @@ check_dependencies() {
 is_valid_gd_path() {
     if [ -z "$1" ]; then
         LAST_VALID_GD_PATH_ERR="No path specified."
-        return -1
+        return 1
     fi
 
     if [ ! -d "$1" ]; then
         LAST_VALID_GD_PATH_ERR="Path is not a directory."
-        return -1
+        return 1
     fi
 
     # Check if cocos2d is there, for good measure
     if [ ! -f "$1/libcocos2d.dll" ]; then
         LAST_VALID_GD_PATH_ERR="Path doesn't contain Geometry Dash."
-        return -1
+        return 1
     fi
 
     return 0
@@ -84,7 +84,7 @@ find_gd_installation() {
         return 0
     fi
 
-    return -1
+    return 1
 }
 
 # Defaults to yes
@@ -92,7 +92,7 @@ confirm() {
     while read -n1 -r -p "$(echo -e $1) [Y/n]: " < /dev/tty; do
         case $REPLY in
             y) return 0 ;;
-            n) echo ""; return -1 ;;
+            n) echo ""; return 1 ;;
             *) return 0;;
         esac
     done

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -23,12 +23,12 @@ verbose_log() {
 
 check_dependencies() {
     if ! [ -x "$(command -v unzip)" ]; then
-        echo -e '${RED}Error${NC}: unzip is not installed.' >&2
+        echo -e "${RED}Error${NC}: unzip is not installed." >&2
         exit 1
     fi
 
     if ! [ -x "$(command -v curl)" ]; then
-        echo -e '${RED}Error${NC}: curl is not installed.' >&2
+        echo -e "${RED}Error${NC}: curl is not installed." >&2
         exit 1
     fi
 }

--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -31,6 +31,11 @@ check_dependencies() {
         echo -e "${RED}Error${NC}: curl is not installed." >&2
         exit 1
     fi
+
+    if ! [ -x "$(command -v jq)" ]; then
+        echo -e "${RED}Error${NC}: jq is not installed." >&2
+        exit 1
+    fi
 }
 
 is_valid_gd_path() {


### PR DESCRIPTION
- fixes installer not checking for jq (but still depending on it)
- fixes invalid internal return codes (they're unsigned integers)
- improves syntax of checking if a command succeeded