### PR TITLE
Added option to force curl to use IPv4

### DIFF
--- a/loader/resources/mod.json.in
+++ b/loader/resources/mod.json.in
@@ -145,7 +145,13 @@
             "default": false,
             "name": "Verbose Curl Logs",
             "description": "When performing web requests, prints detailed information about the request to the logs. Useful for developers wanting to debug network issues."
-        }
+        },
+		"curl-force-ipv4": {
+			"type": "bool",
+			"default": false,
+			"name": "Curl Uses IPv4",
+			"description": "When performing web requests, Curl will use IPv4 instead of IPv6."
+		}
     },
     "issues": {
         "info": "Post your issues on the <cp>Geode Github Repository</c>. <cy>Please follow the standard issue format</c>.",

--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -562,6 +562,13 @@ WebTask WebRequest::send(std::string_view method, std::string_view url) {
         // Do not fail if response code is 4XX or 5XX
         curl_easy_setopt(curl, CURLOPT_FAILONERROR, 0L);
 
+		// IPv4
+		if (Mod::get()->getSettingValue<bool>("curl-force-ipv4")) {
+			curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+		} else {
+			curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
+		}
+
         // Verbose logging
         if (Mod::get()->getSettingValue<bool>("verbose-curl-logs")) {
             curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
I was having trouble with Curl. The literal only way I could get it to work was forcing it to use IPv4 instead of IPv6. Geode doesn't have an option to force IPv4 (not that I know of at least) so I added this. Made the shit work for me. Hopefully this could help someone in the future, too.