### PR TITLE
Add new launch flag ("binary-dir") & Change the path for loading mods

### DIFF
--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -133,6 +133,10 @@ std::filesystem::path Mod::Impl::getTempDir() const {
 }
 
 std::filesystem::path Mod::Impl::getBinaryPath() const {
+    if (auto value = Loader::get()->getLaunchArgument("binary-dir")) {
+        log::debug("Using custom binary directory: {}", value.value());
+        return std::filesystem::path(value.value()) / m_metadata.getBinaryName();
+    }
     return m_tempDirName / m_metadata.getBinaryName();
 }
 

--- a/loader/src/platform/android/ModImpl.cpp
+++ b/loader/src/platform/android/ModImpl.cpp
@@ -16,7 +16,7 @@ T findSymbolOrMangled(void* so, char const* name, char const* mangled) {
 
 Result<> Mod::Impl::loadPlatformBinary() {
     auto so =
-        dlopen((m_tempDirName / m_metadata.getBinaryName()).string().c_str(), RTLD_LAZY);
+        dlopen(this->getBinaryPath().string().c_str(), RTLD_LAZY);
     if (so) {
         if (m_platformInfo) {
             delete m_platformInfo;

--- a/loader/src/platform/ios/ModImpl.cpp
+++ b/loader/src/platform/ios/ModImpl.cpp
@@ -17,7 +17,7 @@ T findSymbolOrMangled(void* dylib, char const* name, char const* mangled) {
 
 Result<> Mod::Impl::loadPlatformBinary() {
     auto dylib =
-        dlopen((m_tempDirName / m_metadata.getBinaryName()).string().c_str(), RTLD_LAZY);
+        dlopen(this->getBinaryPath().string().c_str(), RTLD_LAZY);
     if (dylib) {
         if (m_platformInfo) {
             delete m_platformInfo;

--- a/loader/src/platform/mac/ModImpl.cpp
+++ b/loader/src/platform/mac/ModImpl.cpp
@@ -17,7 +17,7 @@ T findSymbolOrMangled(void* dylib, char const* name, char const* mangled) {
 
 Result<> Mod::Impl::loadPlatformBinary() {
     auto dylib =
-        dlopen((m_tempDirName / m_metadata.getBinaryName()).string().c_str(), RTLD_LAZY);
+        dlopen(this->getBinaryPath().string().c_str(), RTLD_LAZY);
     if (dylib) {
         if (m_platformInfo) {
             delete m_platformInfo;

--- a/loader/src/platform/windows/ModImpl.cpp
+++ b/loader/src/platform/windows/ModImpl.cpp
@@ -54,7 +54,7 @@ std::string getLastWinError() {
 }
 
 Result<> Mod::Impl::loadPlatformBinary() {
-    auto load = LoadLibraryW((m_tempDirName / m_metadata.getBinaryName()).wstring().c_str());
+    auto load = LoadLibraryW(this->getBinaryPath().wstring().c_str());
     if (load) {
         if (m_platformInfo) {
             delete m_platformInfo;


### PR DESCRIPTION
This updates the old code from using `(m_tempDirName / m_metadata.getBinaryName()` to using `this->getBinaryPath()`, which essentially does the same thing.
```diff
-        dlopen((m_tempDirName / m_metadata.getBinaryName()).string().c_str(), RTLD_LAZY);
+        dlopen(this->getBinaryPath().string().c_str(), RTLD_LAZY);
```

This also adds a new launch flag titled `binary-dir`

Example usage:
`--geode:binary-dir="Z:\home\fire\custom-binary-directory"`
All mod binaries will be loaded from that directory, rather than `geode/unzipped/[mod id]/[mod id].dylib` as an example.