### PR TITLE
add CCNode::getChildByIndex

### DIFF
--- a/loader/include/Geode/cocos/base_nodes/CCNode.h
+++ b/loader/include/Geode/cocos/base_nodes/CCNode.h
@@ -648,7 +648,7 @@ public:
     inline auto getChildrenExt() {
         // CCArrayExt is defined in geode/utils/cocos.hpp, which we cannot include due to circular includes.
         // This is an incredibly hacky way to still be able to use the type
-        
+
         using CCArrayExt = geode::CCArrayExtCheck<T, PleaseDontChangeMe>::type;
         static_assert(!std::is_void_v<CCArrayExt>, "Please include <Geode/utils/cocos.hpp> to use getChildrenExt()");
 
@@ -1143,6 +1143,23 @@ public:
     GEODE_DLL void removeEventListener(std::string const& id);
     GEODE_DLL geode::EventListenerProtocol* getEventListener(std::string const& id);
     GEODE_DLL size_t getEventListenerCount();
+
+    /**
+     * Get child at index. Checks bounds. A negative
+     * index will get the child starting from the end
+     * @returns Child at index cast to the given type,
+     * or nullptr if index exceeds bounds
+     */
+    template <class InpT = cocos2d::CCNode*, class T = std::remove_pointer_t<InpT>>
+    T* getChildByIndex(int i) {
+        // start from end for negative index
+        if (i < 0) i = this->getChildrenCount() + i;
+        // check if backwards index is out of bounds
+        if (i < 0) return nullptr;
+        // check if forwards index is out of bounds
+        if (static_cast<int>(this->getChildrenCount()) <= i) return nullptr;
+        return static_cast<T*>(this->getChildren()->objectAtIndex(i));
+    }
 
     /**
      * Get nth child that is a given type. Checks bounds.

--- a/loader/include/Geode/utils/cocos.hpp
+++ b/loader/include/Geode/utils/cocos.hpp
@@ -642,18 +642,13 @@ namespace geode::cocos {
     /**
      * Get child at index. Checks bounds. A negative
      * index will get the child starting from the end
+     * @deprecated Use CCNode::getChildByIndex instead
      * @returns Child at index cast to the given type,
      * or nullptr if index exceeds bounds
      */
     template <class T = cocos2d::CCNode>
     static T* getChild(cocos2d::CCNode* x, int i) {
-        // start from end for negative index
-        if (i < 0) i = x->getChildrenCount() + i;
-        // check if backwards index is out of bounds
-        if (i < 0) return nullptr;
-        // check if forwards index is out of bounds
-        if (static_cast<int>(x->getChildrenCount()) <= i) return nullptr;
-        return static_cast<T*>(x->getChildren()->objectAtIndex(i));
+        return x->getChildByIndex<T>(i);
     }
 
     /**


### PR DESCRIPTION
The free function `getChild`, copied into CCNode as `CCNode::getChildByIndex`, in a similar fashion to how `getChildOfType` was moved into CCNode as `CCNode::getChildByType`.

On the next major release, I would recommend removing the free function `getChild` (just like `getChildOfType` was removed), and potentially maybe renaming `CCNode::getChildByIndex` to `CCNode::getChild`; I chose not to name it like so now because it seems to break compilation on mods that use the free getChild function, without qualifying it like `::getChild`, unless, of course, you think `CCNode::getChildByIndex` is a better name than `CCNode::getChild` and can stay.