### PR TITLE
Progress bar helper classes

### DIFF
--- a/loader/include/Geode/UI.hpp
+++ b/loader/include/Geode/UI.hpp
@@ -17,6 +17,8 @@
 #include "ui/MDTextArea.hpp"
 #include "ui/Notification.hpp"
 #include "ui/Popup.hpp"
+#include "ui/ProgressBar.hpp"
+#include "ui/ProgressBarSolid.hpp"
 #include "ui/SceneManager.hpp"
 #include "ui/Scrollbar.hpp"
 #include "ui/ScrollLayer.hpp"

--- a/loader/include/Geode/ui/ProgressBar.hpp
+++ b/loader/include/Geode/ui/ProgressBar.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cocos2d.h>
+
+namespace geode {
+    // Custom class for the progress bar
+    class ProgressBar : public cocos2d::CCNode {
+    protected:
+        Ref<CCSprite> m_progressBar = nullptr; // Progress bar outline
+        CCSprite* m_progressBarFill = nullptr; // Progress bar fill
+
+        float m_progress = 0.f; // Current progress bar fill percentage ranging from 0 to 100
+
+        float m_progressBarFillMaxWidth = 0.f; // Max width for the progress fill bar node
+        float m_progressBarFillMaxHeight = 0.f; // Max height for the progress fill bar node
+
+        bool init() override;
+
+    public:
+        // Create a custom progress bar
+        static ProgressBar* create();
+
+        /**
+         * Set the color of the fill of the bar
+         *
+         * @param color RGB color object
+         */
+        void setProgressBarFillColor(ccColor3B color);
+
+        /**
+         * Update the size of the fill of the bar
+         *
+         * @param value A float from 0 to 100
+         */
+        virtual void updateProgress(float value);
+
+        /**
+         * Get the current progress percentage of the bar
+         */
+        float getProgress();
+    };
+}

--- a/loader/include/Geode/ui/ProgressBarSolid.hpp
+++ b/loader/include/Geode/ui/ProgressBarSolid.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cocos2d.h>
+#include <Geode/ui/ProgressBar.hpp>
+
+namespace geode {
+    // Custom class for the Normal/Practice mode style progress bar
+    class ProgressBarSolid : public ProgressBar {
+    protected:
+        CCLabelBMFont* m_progressPercentLabel = nullptr; // The text label displaying the percentage
+
+        bool init() override;
+
+    public:
+        // Create a custom progress bar
+        static ProgressBarSolid* create();
+
+        /**
+         * Update the size of the fill of the bar and the percentage label
+         *
+         * @param value A float from 0 to 100
+         */
+        void updateProgress(float value) override;
+
+        /**
+         * Get the progress percentage text label node
+         */
+        CCLabelBMFont* getProgressLabel();
+    };
+}

--- a/loader/src/ui/nodes/ProgressBar.cpp
+++ b/loader/src/ui/nodes/ProgressBar.cpp
@@ -1,0 +1,67 @@
+#include <cocos2d.h>
+#include <Geode/ui/ProgressBar.hpp>
+
+using namespace geode::prelude;
+
+bool ProgressBar::init() {
+    if (!CCNode::init()) return false;
+
+    this->setID("bar"_spr);
+
+    m_progressBar = CCSprite::create("slidergroove2.png");
+    m_progressBar->setID("progress-bar");
+    m_progressBar->setPosition({ m_progressBar->getScaledContentWidth() / 2.f, m_progressBar->getScaledContentHeight() / 2.f });
+    m_progressBar->setAnchorPoint({ 0.5, 0.5 });
+    m_progressBar->setZOrder(501);
+
+    this->setScaledContentSize(m_progressBar->getScaledContentSize());
+
+    m_progressBarFill = CCSprite::create("sliderBar2.png");
+    m_progressBarFill->setID("bar-fill");
+    m_progressBarFill->setAnchorPoint({ 0, 0.5 });
+    m_progressBarFill->setPosition({ 2.f, m_progressBar->getScaledContentHeight() / 2.f });
+    m_progressBarFill->setColor({ 255, 255, 255 });
+    m_progressBarFill->setZOrder(-1);
+
+    m_progressBarFillMaxWidth = m_progressBar->getScaledContentWidth() - 4.f;
+    m_progressBarFillMaxHeight = m_progressBarFill->getScaledContentHeight();
+
+    m_progressBar->addChild(m_progressBarFill);
+
+    this->addChild(m_progressBar);
+    this->updateProgress(0.0f);
+
+    return true;
+};
+
+void ProgressBar::setProgressBarFillColor(ccColor3B color) {
+    if (m_progressBarFill) m_progressBarFill->setColor(color);
+};
+
+void ProgressBar::updateProgress(float value) {
+    if (value > 100.0f) value = 100.0f;
+    if (value < 0.0f) value = 0.0f;
+
+    m_progress = value;
+
+    if (m_progressBar && m_progressBarFill) {
+        float width = m_progressBarFillMaxWidth * (m_progress / 100.f);
+        m_progressBarFill->setTextureRect({ 0.f, 0.f, width, m_progressBarFillMaxHeight });
+    };
+};
+
+float ProgressBar::getProgress() {
+    return m_progress;
+};
+
+ProgressBar* ProgressBar::create() {
+    auto ret = new ProgressBar();
+
+    if (ret && ret->init()) {
+        ret->autorelease();
+        return ret;
+    };
+
+    CC_SAFE_DELETE(ret);
+    return nullptr;
+};

--- a/loader/src/ui/nodes/ProgressBarSolid.cpp
+++ b/loader/src/ui/nodes/ProgressBarSolid.cpp
@@ -1,0 +1,73 @@
+#include <cocos2d.h>
+#include <Geode/ui/ProgressBar.hpp>
+#include <Geode/ui/ProgressBarSolid.hpp>
+
+using namespace geode::prelude;
+
+bool ProgressBarSolid::init() {
+    if (!CCNode::init()) return false;
+
+    this->setID("bar-solid"_spr);
+
+    m_progressBar = CCSprite::create("GJ_progressBar_001.png");
+    m_progressBar->setID("progress-bar");
+    m_progressBar->setAnchorPoint({ 0.5, 0.5 });
+    m_progressBar->setPosition({ m_progressBar->getScaledContentWidth() / 2.f, m_progressBar->getScaledContentHeight() / 2.f });
+    m_progressBar->setColor({ 0, 0, 0 });
+    m_progressBar->setOpacity(125);
+
+    this->setScaledContentSize(m_progressBar->getScaledContentSize());
+
+    m_progressBarFill = CCSprite::create("GJ_progressBar_001.png");
+    m_progressBarFill->setID("bar-fill");
+    m_progressBarFill->setScale(0.992f);
+    m_progressBarFill->setScaleY(0.86f);
+    m_progressBarFill->setAnchorPoint({ 0, 0.5 });
+    m_progressBarFill->setPosition({ 1.36f, m_progressBar->getScaledContentHeight() / 2.f });
+    m_progressBarFill->setColor({ 255, 255, 255 });
+    m_progressBarFill->setZOrder(1);
+
+    m_progressBarFillMaxWidth = m_progressBar->getScaledContentWidth();
+    m_progressBarFillMaxHeight = 20.f;
+
+    m_progressBar->addChild(m_progressBarFill);
+
+    this->addChild(m_progressBar);
+    this->updateProgress(0.0f);
+
+    m_progressPercentLabel = CCLabelBMFont::create("0%", "bigFont.fnt");
+    m_progressPercentLabel->setID("percent-label");
+    m_progressPercentLabel->setScale(0.5f);
+    m_progressPercentLabel->setAnchorPoint({ 0.5, 0.5 });
+    m_progressPercentLabel->setPosition({ getScaledContentWidth() / 2.f, getScaledContentHeight() / 2.f });
+    m_progressPercentLabel->setZOrder(2);
+
+    this->addChild(m_progressPercentLabel);
+
+    return true;
+};
+
+void ProgressBarSolid::updateProgress(float value) {
+    ProgressBar::updateProgress(value);
+
+    if (m_progressPercentLabel) {
+        auto percentString = fmt::format("{}%", static_cast<int>(m_progress));
+        m_progressPercentLabel->setCString(percentString.c_str());
+    };
+};
+
+CCLabelBMFont* ProgressBarSolid::getProgressLabel() {
+    return m_progressPercentLabel;
+};
+
+ProgressBarSolid* ProgressBarSolid::create() {
+    auto ret = new ProgressBarSolid();
+
+    if (ret && ret->init()) {
+        ret->autorelease();
+        return ret;
+    };
+
+    CC_SAFE_DELETE(ret);
+    return nullptr;
+};


### PR DESCRIPTION
Since the base game doesn't use a class to create its progress bar UI, I would like to propose some helper classes that I wrote that can help developers easily re-create them without having to use the sprites and set the texture rects themselves.

### `ProgressBar`
This class creates a progress bar that mimics the style of the progress bar shown when progressing through a classic level. It inherits `cocos2d::CCNode`.
```hpp
static ProgressBar* create(); // Create the custom progress bar

void setProgressBarFillColor(ccColor3B color); // Set the color of the fill of the bar
void updateProgress(float value); // Update the size of the fill of the bar

float getProgress(); // Get the current progress percentage of the bar
```

###### Example
```cpp
auto bar = ProgressBar::create();
bar->setProgressBarFillColor({255, 100, 100});
bar->updateProgress(20.5f); // Sets to 20.5% full
this->addChild(bar);
```

### `ProgressBarSolid`
This class, which inherits `ProgressBar`,  creates a progress bar that imitates the style of the Normal mode and Practice mode progress bars seen when pausing and before playing a level.
```hpp
static ProgressBarSolid* create(); // Create a custom progress bar

void updateProgress(float value) override; // Update the size of the fill of the bar

CCLabelBMFont* getProgressLabel(); // Get the progress percentage text label node
```

###### Example
```cpp
auto bar = ProgressBarSolid::create();
bar->setProgressBarFillColor({255, 100, 100});
bar->updateProgress(75.0f); // Sets to 75% full
this->addChild(bar);

auto barPercentLabel = bar->getProgressLabel();
barPercentLabel->setVisible(false);
```