### PR TITLE
Add SYSTEM to target_include_directories for bindings and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,7 @@ if (NOT GEODE_DISABLE_PRECOMPILED_HEADERS)
 	)
 endif()
 
-target_include_directories(GeodeBindings PUBLIC
+target_include_directories(GeodeBindings SYSTEM PUBLIC
 	${GEODE_LOADER_PATH}/include
 	${GEODE_LOADER_PATH}/include/Geode/cocos/include
 	${GEODE_LOADER_PATH}/include/Geode/cocos/extensions

--- a/cmake/GeodeFile.cmake
+++ b/cmake/GeodeFile.cmake
@@ -264,7 +264,7 @@ function(setup_geode_mod proname)
         endforeach()
 
         # Link libs
-        target_include_directories(${proname} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/geode-deps")
+        target_include_directories(${proname} SYSTEM PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/geode-deps")
         target_link_libraries(${proname} ${libs_to_link})
         
     endif()


### PR DESCRIPTION
Warnings from Geode or mods' dependencies may clutter other mod developers' compilation, or cause errors if they're using `-Werror`. Change the target include directories to SYSTEM in order to silence these.

CMake does claim this:
> Additionally, system include directories are searched after normal include directories regardless of the order specified.

I am not sure if that could cause any issues, but it's worth keeping in mind I guess.