### PR TITLE
Add function for opening keybinds popup

### DIFF
--- a/loader/include/Geode/ui/GeodeUI.hpp
+++ b/loader/include/Geode/ui/GeodeUI.hpp
@@ -2,6 +2,7 @@
 
 #include "../loader/Mod.hpp"
 #include <Geode/binding/FLAlertLayer.hpp>
+#include <Geode/loader/SettingV3.hpp>
 #include <Geode/ui/Popup.hpp>
 
 class ModPopup;
@@ -88,6 +89,14 @@ namespace geode {
      * settings
      */
     GEODE_DLL Popup* openSettingsPopup(Mod* mod, bool disableGeodeTheme);
+
+    /**
+     * Open the keybinds popup and navigate to a specific tab (if `std::nullopt` is passed then same tab user was on previously)
+     * @param mod If not null, keybinds of other mods will be collapsed
+     * @returns A pointer to the created Popup
+     */
+    GEODE_DLL Popup* openKeybindsPopup(std::optional<KeybindCategory> category, Mod* mod);
+
     /**
      * Create a default logo sprite
      */

--- a/loader/src/ui/GeodeUI.cpp
+++ b/loader/src/ui/GeodeUI.cpp
@@ -9,6 +9,7 @@
 #include <server/Server.hpp>
 #include "mods/GeodeStyle.hpp"
 #include "mods/settings/ModSettingsPopup.hpp"
+#include "mods/settings/KeybindsPopup.hpp"
 #include "mods/popups/ModPopup.hpp"
 
 class LoadServerModLayer : public Popup {
@@ -197,7 +198,7 @@ std::optional<arc::TaskHandle<bool>> geode::openInfoPopup(std::string modID) {
                 popup->show();
             });
         }
-        
+
         co_return ret;
     });
 }
@@ -218,6 +219,19 @@ Popup* geode::openSettingsPopup(Mod* mod, bool disableGeodeTheme) {
         return popup;
     }
     return nullptr;
+}
+
+Popup* geode::openKeybindsPopup(std::optional<KeybindCategory> category, Mod* mod) {
+    auto tab = KeybindsPopupTab::All;
+    if (category) switch (*category) {
+        case KeybindCategory::Universal: tab = KeybindsPopupTab::Universal; break;
+        case KeybindCategory::Gameplay: tab = KeybindsPopupTab::Gameplay; break;
+        case KeybindCategory::Editor: tab = KeybindsPopupTab::Editor; break;
+    }
+
+    auto popup = KeybindsPopup::create(tab, mod);
+    popup->show();
+    return popup;
 }
 
 using ModLogoSrc = std::variant<Mod*, std::string, std::filesystem::path>;

--- a/loader/src/ui/mods/settings/KeybindsPopup.hpp
+++ b/loader/src/ui/mods/settings/KeybindsPopup.hpp
@@ -16,11 +16,13 @@ protected:
     KeybindsPopupTab m_tab = KeybindsPopupTab::All;
     CCMenu* m_tabsMenu;
 
-    bool init(bool forceDisableTheme);
+    bool init(std::optional<KeybindsPopupTab> tab, Mod* mod, bool forceDisableTheme);
     bool shouldShow(SettingNode* node) const override;
 
     void onSelectTab(CCObject*);
+    void focusMod(Mod* mod);
 
 public:
     static KeybindsPopup* create(bool forceDisableTheme = false);
+    static KeybindsPopup* create(std::optional<KeybindsPopupTab> tab, Mod* mod, bool forceDisableTheme = false);
 };

--- a/loader/src/ui/mods/settings/SettingNodeV3.cpp
+++ b/loader/src/ui/mods/settings/SettingNodeV3.cpp
@@ -17,7 +17,7 @@ public:
     CCLabelBMFont* statusLabel;
     ccColor4B bgColor = ccc4(0, 0, 0, 0);
     bool committed = false;
-    // This is because you can create `TitleSettingNodeV3`s without having an 
+    // This is because you can create `TitleSettingNodeV3`s without having an
     // actual `TitleSettingV3`
     std::optional<std::string> customDescription;
 };
@@ -244,6 +244,11 @@ void TitleSettingNodeV3::onCommit() {}
 
 bool TitleSettingNodeV3::isCollapsed() const {
     return m_collapseToggle->isToggled();
+}
+
+void TitleSettingNodeV3::setCollapsed(bool collapsed) {
+    m_collapseToggle->toggle(collapsed);
+    this->markChanged(m_collapseToggle);
 }
 
 bool TitleSettingNodeV3::hasUncommittedChanges() const {

--- a/loader/src/ui/mods/settings/SettingNodeV3.hpp
+++ b/loader/src/ui/mods/settings/SettingNodeV3.hpp
@@ -29,6 +29,7 @@ public:
     static TitleSettingNodeV3* create(ZStringView title, std::optional<ZStringView> description, float width);
 
     bool isCollapsed() const;
+    void setCollapsed(bool collapsed);
 
     bool hasUncommittedChanges() const override;
     bool hasNonDefaultValue() const override;


### PR DESCRIPTION
Allows mods to open a keybinds popup, and to navigate to a specific page and show only that mod's keybinds.

e.g. this code in Globed results in the following popup being opened

```cpp
geode::openKeybindsPopup(std::nullopt, Mod::get());
```

<img width="1361" height="776" alt="image" src="https://github.com/user-attachments/assets/d7f3313d-f355-4574-9690-1c92348f7cfc" />



The implementation might not be the best, specifically the "collapse" all other mods part; could make the title setting always store a mod to remove need for string comparison