### PR TITLE
Add quick layer push util

### DIFF
--- a/loader/include/Geode/ui/General.hpp
+++ b/loader/include/Geode/ui/General.hpp
@@ -104,8 +104,8 @@ namespace geode {
     };
 
     /**
-     * Push a layer to the scene
-     * @param layer Layer to push
+     * Push a scene with a CCLayer with a fade transition
+     * @param layer CCLayer to push scene with
      */
     void pushSceneWithLayer(cocos2d::CCLayer* layer);
 

--- a/loader/include/Geode/ui/General.hpp
+++ b/loader/include/Geode/ui/General.hpp
@@ -103,6 +103,12 @@ namespace geode {
         float getBottomPadding();
     };
 
+    /**
+     * Push a layer to the scene
+     * @param to Layer to push
+     */
+    void pushSceneWithLayer(cocos2d::CCLayer* layer);
+
     enum class BackButtonStyle {
         Green,
         Blue,

--- a/loader/include/Geode/ui/General.hpp
+++ b/loader/include/Geode/ui/General.hpp
@@ -105,7 +105,7 @@ namespace geode {
 
     /**
      * Push a layer to the scene
-     * @param to Layer to push
+     * @param layer Layer to push
      */
     void pushSceneWithLayer(cocos2d::CCLayer* layer);
 

--- a/loader/include/Geode/ui/General.hpp
+++ b/loader/include/Geode/ui/General.hpp
@@ -107,7 +107,7 @@ namespace geode {
      * Push a scene with a CCLayer with a fade transition
      * @param layer CCLayer to push scene with
      */
-    void pushSceneWithLayer(cocos2d::CCLayer* layer);
+    GEODE_DLL void pushSceneWithLayer(cocos2d::CCLayer* layer);
 
     enum class BackButtonStyle {
         Green,

--- a/loader/src/ui/nodes/General.cpp
+++ b/loader/src/ui/nodes/General.cpp
@@ -239,6 +239,13 @@ float ListBorders::getBottomPadding() {
     return m_impl->bottomPadding;
 }
 
+void geode::pushSceneWithLayer(cocos2d::CCLayer *layer) {
+    auto scene = CCScene::create();
+    scene->addChild(layer);
+
+    CCDirector::sharedDirector()->pushScene(CCTransitionFade::create(.5f, scene));
+}
+
 CCMenuItemSpriteExtra* geode::addBackButton(cocos2d::CCNode* to, BackButtonStyle style) {
     return geode::addBackButton(to, [](cocos2d::CCMenuItem*) { CCDirector::get()->popSceneWithTransition(.5f, PopTransition::kPopTransitionFade); }, style);
 }


### PR DESCRIPTION
Add a convenient one-line util function to push a scene with your CCLayer without having to create a whole new `scene()` function and pushing it yourself.

Simply provide a pointer to the layer with your `create()` method.
```cpp
geode::pushSceneWithLayer(MyLayer::create());
```

This will automatically create a new CCScene and push it with a 0.5-second long transition fade.

The intention is simply to help reduce boilerplate in mods' UI code!