### PR TITLE
Add PopupManager for queueing popups & managing other stuff

### DIFF
--- a/loader/include/Geode/ui/PopupManager.hpp
+++ b/loader/include/Geode/ui/PopupManager.hpp
@@ -40,8 +40,8 @@ public:
     void blockClosingFor(const asp::time::Duration& dur);
 
     // Makes it impossible to accidentally close the popup (via esc or back button)
-    // for a given period of time (in ms) after it is shown.
-    void blockClosingFor(int durMillis);
+    // for a given period of time (in seconds) after it is shown.
+    void blockClosingFor(float dur);
 
     // Shows the popup to the user immediately, does nothing if already shown.
     void showInstant();

--- a/loader/include/Geode/ui/PopupManager.hpp
+++ b/loader/include/Geode/ui/PopupManager.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <Geode/binding/FLAlertLayer.hpp>
+#include <Geode/utils/cocos.hpp>
+#include <Geode/utils/ZStringView.hpp>
+#include <Geode/ui/Notification.hpp>
+
+#include <deque>
+
+namespace geode {
+
+class [[nodiscard("call showQueue or showInstant to show the popup")]] GEODE_DLL ManagedPopup {
+    friend class PopupManager;
+    struct Data;
+
+public:
+    ManagedPopup(FLAlertLayer* layer);
+    ManagedPopup();
+
+    ManagedPopup(const ManagedPopup& other) = default;
+    ManagedPopup& operator=(const ManagedPopup& other) = default;
+    ManagedPopup(ManagedPopup&& other) noexcept = default;
+    ManagedPopup& operator=(ManagedPopup&& other) noexcept = default;
+
+    operator FLAlertLayer*() const;
+    FLAlertLayer* operator->() const;
+    FLAlertLayer* getInner() const;
+
+    // Set whether the popup should follow the user if they transition to another scene,
+    // instead of disappearing. By default is disabled.
+    void setPersistent(bool state = true);
+
+    // Makes the popup prioritized, ensuring that it will be put in front of the queue,
+    // and shown even if the user is playing a level (the level will be paused).
+    // Only effective if `showQueue()` is used, if `showInstant()` is used the popup already shows immediately.
+    void setPriority(bool state = true);
+
+    // Makes it impossible to accidentally close the popup (via esc or back button)
+    // for a given period of time after it is shown.
+    void blockClosingFor(const asp::time::Duration& dur);
+
+    // Makes it impossible to accidentally close the popup (via esc or back button)
+    // for a given period of time (in ms) after it is shown.
+    void blockClosingFor(int durMillis);
+
+    // Shows the popup to the user immediately, does nothing if already shown.
+    void showInstant();
+
+    // Queues the popup to be shown to the user when it's appropriate,
+    // e.g. not while they're in a level and unpaused or in the middle of a transition
+    // This should be the preferred way of showing a popup, and will work as intended when inside e.g. an `init` method of a layer.
+    void showQueue();
+
+    bool isShown();
+
+    bool shouldPreventClosing();
+
+private:
+    geode::Ref<FLAlertLayer> inner;
+
+    Data& getFields();
+    bool hasFields() const;
+    void doShow(bool reshowing = false);
+};
+
+class GEODE_DLL PopupManager final : public cocos2d::CCObject {
+    friend class SingletonNodeBase;
+    friend class ManagedPopup;
+    PopupManager();
+
+public:
+    constexpr static float DEFAULT_WIDTH = 370.f;
+
+    PopupManager(const PopupManager&) = delete;
+    PopupManager& operator=(const PopupManager&) = delete;
+    PopupManager(PopupManager&&) = delete;
+    PopupManager& operator=(PopupManager&&) = delete;
+
+    static PopupManager& get();
+
+    // Creates a popup with the given title and content (optionally button 1, 2 and width). Does not show the popup to the user.
+    ManagedPopup alert(
+        ZStringView title,
+        const std::string& content,
+        ZStringView btn1 = "Ok",
+        ZStringView btn2 = nullptr,
+        float width = DEFAULT_WIDTH
+    );
+
+    // Creates a popup with the given title and content (optionally button 1, 2 and width). Does not show the popup to the user.
+    // The callback is involved when the user presses either of the buttons in the popup.
+    ManagedPopup quickPopup(
+        ZStringView title,
+        const std::string& content,
+        ZStringView btn1 = "Ok",
+        ZStringView btn2 = nullptr,
+        geode::Function<void (FLAlertLayer*, bool)> callback = {},
+        float width = DEFAULT_WIDTH
+    );
+
+    // Creates a popup with the given title and content as a formatted string. Does not show the popup to the user.
+    template <class... Args>
+    ManagedPopup alertFormat(
+        ZStringView title,
+        fmt::format_string<Args...> fmt,
+        Args&&... args
+    ) {
+        return alert(title, fmt::format(fmt, std::forward<Args>(args)...));
+    }
+
+    // Create a ManagedPopup for this custom popup that can be used to manage it.
+    // Don't call this if the popup has already been shown.
+    ManagedPopup manage(FLAlertLayer* alert);
+
+    bool isManaged(FLAlertLayer* alert);
+
+    // Returns whether there are currently any queued popups that can't be shown,
+    // either because the player is transitioning or in a level and unpaused.
+    bool hasPendingPopups() const;
+
+private:
+    cocos2d::CCScene* m_prevScene = nullptr;
+    bool m_isTransitioning = false;
+    std::vector<Ref<FLAlertLayer>> m_savedAlerts;
+    std::deque<ManagedPopup> m_queuedPopups;
+
+    void changedScene(cocos2d::CCScene* newScene);
+    void queuePopup(const ManagedPopup& popup, bool back = true);
+    void update(float dt);
+};
+
+}

--- a/loader/src/hooks/MenuLayer.cpp
+++ b/loader/src/hooks/MenuLayer.cpp
@@ -7,6 +7,7 @@
 #include <Geode/ui/BasedButtonSprite.hpp>
 #include <Geode/ui/Notification.hpp>
 #include <Geode/ui/Popup.hpp>
+#include <Geode/ui/PopupManager.hpp>
 #include <Geode/ui/MDPopup.hpp>
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/web.hpp>
@@ -143,24 +144,22 @@ struct CustomMenuLayer : Modify<CustomMenuLayer, MenuLayer> {
         // show in safe mode
         auto isSafeMode = LoaderImpl::get()->isSafeMode();
         if (isSafeMode) {
-            Loader::get()->queueInMainThread([] {
-                auto popup = createQuickPopup(
-                    "Safe Mode",
-                    "Geode is running in <cy>Safe Mode</c>.\n"
-                    "Mods are <cr>not loaded</c> in this mode.\n"
-                    "\n"
-                    "You can use this to <co>disable</c> or <co>update</c> mods "
-                    "causing issues but all mod features\n"
-                    "<cy>are not available</c>.",
-                    "OK",
-                    nullptr,
-                    [](auto, bool btn2) {},
-                    false
-                );
+            auto popup = PopupManager::get().quickPopup(
+                "Safe Mode",
+                "Geode is running in <cy>Safe Mode</c>.\n"
+                "Mods are <cr>not loaded</c> in this mode.\n"
+                "\n"
+                "You can use this to <co>disable</c> or <co>update</c> mods "
+                "causing issues but all mod features\n"
+                "<cy>are not available</c>.",
+                "OK",
+                nullptr,
+                [](auto, bool btn2) {},
+                false
+            );
 
-                popup->m_noElasticity = true;
-                popup->show();
-            });
+            popup->m_noElasticity = true;
+            popup.showQueue();
         }
 
         // show if the user tried to be naughty and load arbitrary DLLs

--- a/loader/src/ui/PopupManager.cpp
+++ b/loader/src/ui/PopupManager.cpp
@@ -1,0 +1,295 @@
+#include <Geode/ui/PopupManager.hpp>
+#include <Geode/Geode.hpp>
+
+#include <asp/time/SystemTime.hpp>
+#include <asp/data/Cow.hpp>
+
+using namespace geode::prelude;
+using namespace asp::time;
+using namespace asp::data;
+
+namespace geode {
+
+static const auto FIELDS_ID = "ManagedPopup-fields"_spr;
+static constexpr int MANAGED_ALERT_TAG = 154385390;
+
+struct ManagedPopup::Data {
+    std::optional<asp::time::Instant> shownAt;
+    asp::time::Duration blockClosingFor;
+    bool persist = false;
+    bool priority = false;
+};
+
+ManagedPopup::ManagedPopup(FLAlertLayer* layer) : inner(layer) {}
+ManagedPopup::ManagedPopup() : inner(nullptr) {}
+
+ManagedPopup::operator FLAlertLayer*() const {
+    return inner;
+}
+
+FLAlertLayer* ManagedPopup::operator->() const {
+    return inner;
+}
+
+FLAlertLayer* ManagedPopup::getInner() const {
+    return inner;
+}
+
+void ManagedPopup::setPersistent(bool state) {
+    this->getFields().persist = state;
+}
+
+void ManagedPopup::setPriority(bool state) {
+    this->getFields().priority = state;
+}
+
+void ManagedPopup::blockClosingFor(const asp::time::Duration& dur) {
+    this->getFields().blockClosingFor = dur;
+}
+
+void ManagedPopup::blockClosingFor(int durMillis) {
+    return this->blockClosingFor(Duration::fromMillis(durMillis));
+}
+
+void ManagedPopup::showInstant() {
+    this->doShow(false);
+}
+
+void ManagedPopup::showQueue() {
+    bool back = !this->getFields().priority;
+    PopupManager::get().queuePopup(*this, back);
+}
+
+bool ManagedPopup::isShown() {
+    return this->inner->getParent();
+}
+
+bool ManagedPopup::shouldPreventClosing() {
+    auto& fields = this->getFields();
+
+    if (!fields.shownAt || fields.blockClosingFor.isZero()) {
+        return false;
+    }
+
+    auto expiry = fields.shownAt.value() + fields.blockClosingFor;
+    return expiry > Instant::now();
+}
+
+void ManagedPopup::doShow(bool reshowing) {
+    if (!reshowing && inner->getParent()) {
+        return;
+    }
+
+    inner->setTag(MANAGED_ALERT_TAG);
+    inner->show();
+
+    auto& fields = this->getFields();
+    fields.shownAt = Instant::now();
+}
+
+ManagedPopup::Data& ManagedPopup::getFields() {
+    using DataT = ObjWrapper<ManagedPopup::Data>;
+
+    auto obj = typeinfo_cast<DataT*>(inner->getUserObject(FIELDS_ID));
+
+    if (!obj) {
+        obj = DataT::create(Data {});
+        inner->setUserObject(FIELDS_ID, obj);
+    }
+
+    return obj->getValue();
+}
+
+bool ManagedPopup::hasFields() const {
+    using DataT = ObjWrapper<ManagedPopup::Data>;
+
+    return typeinfo_cast<DataT*>(inner->getUserObject(FIELDS_ID));
+}
+
+// PopupManager
+
+PopupManager::PopupManager() {
+    CCScheduler::get()->scheduleUpdateForTarget(this, 0, false);
+}
+
+PopupManager& PopupManager::get() {
+    static PopupManager instance;
+    return instance;
+}
+
+ManagedPopup PopupManager::alert(
+    ZStringView title,
+    const std::string& content,
+    ZStringView btn1,
+    ZStringView btn2,
+    float width
+) {
+    auto alert = FLAlertLayer::create(
+        nullptr,
+        title.c_str(),
+        content,
+        btn1.c_str(),
+        btn2.empty() ? nullptr : btn2.c_str(),
+        width
+    );
+    return this->manage(alert);
+}
+
+ManagedPopup PopupManager::quickPopup(
+    ZStringView title,
+    const std::string& content,
+    ZStringView btn1,
+    ZStringView btn2,
+    geode::Function<void (FLAlertLayer*, bool)> callback,
+    float width
+) {
+    auto alert = createQuickPopup(
+        title.c_str(),
+        content,
+        btn1.c_str(),
+        btn2.empty() ? nullptr : btn2.c_str(),
+        std::move(callback),
+        false
+    );
+    return this->manage(alert);
+}
+
+ManagedPopup PopupManager::manage(FLAlertLayer* alert) {
+    return ManagedPopup{alert};
+}
+
+bool PopupManager::isManaged(FLAlertLayer* alert) {
+    return this->manage(alert).hasFields();
+}
+
+void PopupManager::queuePopup(const ManagedPopup& popup, bool back) {
+    if (back) {
+        m_queuedPopups.push_back(popup);
+    } else {
+        m_queuedPopups.push_front(popup);
+    }
+}
+
+bool PopupManager::hasPendingPopups() const {
+    return !m_queuedPopups.empty();
+}
+
+void PopupManager::update(float dt) {
+    auto scene = CCScene::get();
+    if (!scene) return;
+
+    if (scene != m_prevScene) {
+        this->changedScene(scene);
+    }
+
+    // check if we are eligible to show a queued popup
+
+    // if there aren't any in the queue, there is nothing to show
+    if (m_queuedPopups.empty()) {
+        return;
+    }
+
+    // check if we are transitioning 🏳️‍⚧️
+    if (m_isTransitioning) {
+        return;
+    }
+
+    // if there's no current layer, don't show anything
+    auto children = scene->getChildrenExt();
+    if (children.empty()) return;
+    auto layer = children[0];
+
+    // if we are in loadinglayer, don't show anything
+    if (typeinfo_cast<LoadingLayer*>(layer)) {
+        return;
+    }
+
+    // if we are playing and are unpaused, only show priority popups
+    bool playing = false;
+    auto gjbgl = PlayLayer::get();
+    if (gjbgl && !gjbgl->m_isPaused) {
+        playing = true;
+    }
+
+    bool didPause = false;
+    while (!m_queuedPopups.empty()) {
+        auto popup = m_queuedPopups.front();
+        bool isPrio = popup.getFields().priority;
+
+        if (playing && !isPrio) {
+            // we are currently playing a level, so we don't want to show non-prio popups
+            // since prio popups are always put to the front of the queue, we know there's no more prio popups left
+            break;
+        }
+
+        if (playing && isPrio && !didPause) {
+            // pause the level
+            if (gjbgl) {
+                gjbgl->pauseGame(false);
+            }
+            didPause = true;
+        }
+
+        // show the popup
+        popup.doShow();
+        m_queuedPopups.pop_front();
+    }
+}
+
+void PopupManager::changedScene(CCScene* newScene) {
+    m_prevScene = newScene;
+
+    auto trans = typeinfo_cast<CCTransitionScene*>(newScene);
+
+    // if we are transitioning, let's save all our popups and bring them to the other scene if needed
+    if (trans) {
+        m_isTransitioning = true;
+
+        std::vector<Ref<FLAlertLayer>> alerts;
+
+        auto oldScene = trans->m_pOutScene;
+
+        for (auto child : oldScene->getChildrenExt()) {
+            if (child->m_nTag == MANAGED_ALERT_TAG) {
+                if (auto alert = typeinfo_cast<FLAlertLayer*>(child)) {
+                    alerts.push_back(alert);
+                }
+            }
+        }
+
+        for (auto& alert : alerts) {
+            alert->removeFromParentAndCleanup(false);
+        }
+
+        m_savedAlerts = std::move(alerts);
+    } else if (m_isTransitioning) {
+        m_isTransitioning = false;
+
+        // if we were transitioning but now switched to the actual scene, restore the popups
+        for (auto& fla : m_savedAlerts) {
+            auto alert = this->manage(fla);
+            if (!alert.hasFields()) continue;
+
+            // only re-show this alert if persistent it enabled or if it has been visible for way too short
+            auto& fields = alert.getFields();
+            auto sinceShown = fields.shownAt.value_or(Instant{}).elapsed();
+            if (sinceShown < Duration::fromSecsF32(1.0f) || fields.persist) {
+                alert.doShow(true);
+
+                // reset the ref in the vector
+                fla = {};
+            }
+        }
+
+        for (auto& fla : m_savedAlerts) {
+            // cleanup those alerts that were not shown again
+            if (fla) {
+                fla->cleanup();
+            }
+        }
+
+        m_savedAlerts.clear();
+    }
+}
+
+}

--- a/loader/src/ui/PopupManager.cpp
+++ b/loader/src/ui/PopupManager.cpp
@@ -47,8 +47,8 @@ void ManagedPopup::blockClosingFor(const asp::time::Duration& dur) {
     this->getFields().blockClosingFor = dur;
 }
 
-void ManagedPopup::blockClosingFor(int durMillis) {
-    return this->blockClosingFor(Duration::fromMillis(durMillis));
+void ManagedPopup::blockClosingFor(float dur) {
+    return this->blockClosingFor(Duration::fromSecsF32(dur).value_or(Duration{}));
 }
 
 void ManagedPopup::showInstant() {

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -11,6 +11,7 @@
 #include <Geode/utils/ranges.hpp>
 #include <Geode/ui/GeodeUI.hpp>
 #include <Geode/ui/SimpleAxisLayout.hpp>
+#include <Geode/ui/PopupManager.hpp>
 #include <Geode/binding/Slider.hpp>
 #include <Geode/binding/SetTextPopup.hpp>
 #include <Geode/binding/SetIDPopup.hpp>
@@ -465,7 +466,7 @@ bool ModsLayer::init() {
 
     auto topListener = NodeProvidingEvent("geode-mods-list-top"_spr).listen([this](cocos2d::CCNode*& nodeOut, std::string_view theme) -> void {
         if (nodeOut) return; // someone overrode it already
-        
+
         if (theme == "sapphire") nodeOut = CCSprite::createWithSpriteFrameName("mods-list-top-sapphire.png"_spr);
         else if (theme == "geometry-dash") nodeOut = CCSprite::createWithSpriteFrameName("mods-list-top-gd.png"_spr);
         else nodeOut = CCSprite::createWithSpriteFrameName("mods-list-top.png"_spr);
@@ -674,14 +675,13 @@ bool ModsLayer::init() {
         label->setScale(0.55f);
         this->addChild(label);
         static int _ = [this] {
-            auto* alert = FLAlertLayer::create(
+            auto alert = PopupManager::get().alert(
                 "Safe Mode Enabled",
                 "Safe Mode has been enabled. This means no mods will be loaded to prevent crashes. Feel free to manage any problematic mods.",
                 "OK"
             );
-            alert->m_scene = this;
             alert->m_noElasticity = true;
-            alert->show();
+            alert.showQueue();
             return 0;
         }();
     }


### PR DESCRIPTION
Copied from Globed with some changes, this class allows you to do a few cool things:

* Queue a popup to be shown later (e.g. once a transition finishes or a player is not playing a level)
* Make a popup persistent and have it re-appear after a scene change until closed (also automatically does it for any managed popups if they were dismissed too quickly)
* Set high and low priority popups, if multiple are queued then high priority ones take precedence and also will be shown regardless of whether the player is in a level.
* Disallow closing the popup for some time, to prevent the user accidentally closing it immediately

First point is arguably the most important one, this proves to be a good solution for popups shown right before transitions (e.g. `init()` in layers) and is way better & easier than the alternative ways.