### PR TITLE
Add Zstd support to `file::Unzip`

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -233,18 +233,19 @@ if (NOT GEODE_BUILDING_DOCS)
 	CPMAddPackage("gh:mity/md4c#release-0.5.2")
 
 	# Zip support (needed for in-memory streams, which zlib's minizip doesn't support)
+	set(MZ_ZSTD ON CACHE INTERNAL "")
 	set(MZ_LZMA OFF CACHE INTERNAL "")
-	set(MZ_ZSTD OFF CACHE INTERNAL "")
 	set(MZ_BZIP2 OFF CACHE INTERNAL "")
 	set(MZ_OPENSSL OFF CACHE INTERNAL "")
 	set(MZ_LIBBSD OFF CACHE INTERNAL "")
 	set(MZ_FETCH_LIBS ON CACHE INTERNAL "" FORCE)
+	set(MZ_ZLIB_FLAVOR "zlib" CACHE INTERNAL "")
 	set(SKIP_INSTALL_ALL ON CACHE INTERNAL "")
 	set(MZ_FORCE_FETCH_LIBS OFF CACHE INTERNAL "" FORCE)
 	# sets ZLIB_LIBRARY and ZLIB_INCLUDE_DIR
 	include(DownloadNetLibs.cmake)
 	
-	CPMAddPackage("gh:geode-sdk/minizip-ng#e9dda96")
+	CPMAddPackage("gh:geode-sdk/minizip-ng#86663d7")
 
 	# Silence warnings from dependencies
 	include(CheckCXXCompilerFlag)

--- a/loader/DownloadNetLibs.cmake
+++ b/loader/DownloadNetLibs.cmake
@@ -58,8 +58,30 @@ target_link_libraries(${PROJECT_NAME} ca-bundle)
 
 if (WIN32)
 	set(ZLIB_LIBRARY "${net_libs_bin_SOURCE_DIR}/zs.lib")
+	set(ZSTD_LIBRARY "${net_libs_bin_SOURCE_DIR}/zstd_static.lib")
 else()
 	set(ZLIB_LIBRARY "${net_libs_bin_SOURCE_DIR}/libz.a")
+	set(ZSTD_LIBRARY "${net_libs_bin_SOURCE_DIR}/libzstd.a")
 endif()
 
 set(ZLIB_INCLUDE_DIR "${net_libs_bin_SOURCE_DIR}/include")
+set(ZSTD_INCLUDE_DIR "${net_libs_bin_SOURCE_DIR}/include")
+
+# libraries needed for minizip
+if (NOT TARGET zstd::libzstd_static)
+	add_library(zstd::libzstd_static STATIC IMPORTED)
+    set_target_properties(zstd::libzstd_static PROPERTIES
+        IMPORTED_LOCATION "${ZSTD_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}"
+    )
+endif()
+if (NOT TARGET ZLIB::ZLIB)
+    add_library(ZLIB::ZLIB STATIC IMPORTED)
+    set_target_properties(ZLIB::ZLIB PROPERTIES
+        IMPORTED_LOCATION "${ZLIB_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIR}"
+    )
+endif()
+
+set(ZSTD_FOUND TRUE)
+set(ZLIB_FOUND TRUE)

--- a/loader/DownloadNetLibs.cmake
+++ b/loader/DownloadNetLibs.cmake
@@ -74,6 +74,14 @@ if (NOT TARGET zstd::libzstd_static)
         IMPORTED_LOCATION "${ZSTD_LIBRARY}"
         INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}"
     )
+
+	if (NOT TARGET zstd::libzstd_shared)
+		add_library(zstd::libzstd_shared ALIAS zstd::libzstd_static)
+	endif()
+	if (NOT TARGET zstd::libzstd)
+		add_library(zstd::libzstd ALIAS zstd::libzstd_static)
+	endif()
+	set(ZSTD_FOUND TRUE CACHE BOOL "" FORCE)
 endif()
 if (NOT TARGET ZLIB::ZLIB)
     add_library(ZLIB::ZLIB STATIC IMPORTED)
@@ -81,7 +89,5 @@ if (NOT TARGET ZLIB::ZLIB)
         IMPORTED_LOCATION "${ZLIB_LIBRARY}"
         INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIR}"
     )
+	set(ZLIB_FOUND TRUE CACHE BOOL "" FORCE)
 endif()
-
-set(ZSTD_FOUND TRUE)
-set(ZLIB_FOUND TRUE)


### PR DESCRIPTION
We already have Zstd for curl, so might as well use it for minizip! Zstd compressed mods (and files in general) are significantly faster to decompress than DEFLATE, as well as usually being slightly smaller.

This simply adds client-side support to allow Zstd compressed zip files to be opened, in the future we could consider to actually compress mods in the github workflow with Zstd.