### PR TITLE
add CCConfiguration fix

### DIFF
--- a/loader/src/hooks/CCConfigurationFix.cpp
+++ b/loader/src/hooks/CCConfigurationFix.cpp
@@ -1,0 +1,17 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/CCConfiguration.hpp>
+
+using namespace geode::prelude;
+
+class $modify(CCConfigurationFix, CCConfiguration) {
+    void gatherGPUInfo() {
+        CCConfiguration::gatherGPUInfo();
+
+        static std::string extensions;
+        if (m_pGlExtensions) {
+            extensions = m_pGlExtensions;
+        }
+
+        m_pGlExtensions = extensions.data();
+    }
+};


### PR DESCRIPTION
cocos2d forgets to reload the extensions string on GL context recreation, which results in a dangling pointer.
the fix is to copy the extensions string to an owned buffer.