### PR TITLE
Save optimization

### DIFF
--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -307,7 +307,7 @@ namespace geode {
                 return res.unwrap();
             }
 
-            auto savedMutable = this->getSaveContainerTemp();
+            auto& savedMutable = this->getSaveContainerTemp();
             savedMutable[key] = matjson::Value(defaultValue);
             return defaultValue;
         }

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -82,6 +82,8 @@ namespace geode {
         friend void GEODE_CALL ::geode_implicit_load(Mod*);
 
         void settingReact(geode::Function<void()> fn);
+        
+        matjson::Value& getSaveContainerTemp();
     public:
         // no copying
         Mod(Mod const&) = delete;
@@ -242,7 +244,6 @@ namespace geode {
         }
 
         matjson::Value& getSaveContainer();
-        matjson::Value& getSaveContainerTemp();
         matjson::Value const& getSaveContainerConst() const;
         matjson::Value& getSavedSettingsData();
 

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -242,6 +242,7 @@ namespace geode {
         }
 
         matjson::Value& getSaveContainer();
+        matjson::Value const& getSaveContainerConst() const;
         matjson::Value& getSavedSettingsData();
 
         /**
@@ -286,7 +287,7 @@ namespace geode {
 
         template <class T>
         T getSavedValue(std::string_view key) {
-            auto& saved = this->getSaveContainer();
+            auto& saved = this->getSaveContainerConst();
             if (auto res = saved.get(key).andThen([](auto&& v) {
                 return v.template as<T>();
             }); res.isOk()) {
@@ -297,13 +298,15 @@ namespace geode {
 
         template <class T>
         T getSavedValue(std::string_view key, T const& defaultValue) {
-            auto& saved = this->getSaveContainer();
+            auto& saved = this->getSaveContainerConst();
             if (auto res = saved.get(key).andThen([](auto&& v) {
                 return v.template as<T>();
             }); res.isOk()) {
                 return res.unwrap();
             }
-            saved[key] = matjson::Value(defaultValue);
+
+            auto savedMutable = this->getSaveContainer();
+            savedMutable[key] = matjson::Value(defaultValue);
             return defaultValue;
         }
 
@@ -316,8 +319,22 @@ namespace geode {
          */
         template <class T>
         T setSavedValue(std::string_view key, T const& value) {
-            auto& saved = this->getSaveContainer();
             auto old = this->getSavedValue<T>(key);
+
+            // optimization: if the value is the same, don't write to the save container
+            // constexpr checks needed to avoid compile errors for types that don't support operator==
+            if constexpr (std::ranges::range<T>) {
+                using Elem = std::ranges::range_value_t<T>;
+                if constexpr (requires(Elem const& a, Elem const& b) { { a == b } -> std::convertible_to<bool>; }) {
+                    if (old == value) return old;
+                }
+            } 
+            else if constexpr (requires(T const& a, T const& b) { { a == b } -> std::convertible_to<bool>; }) {
+                if (old == value) return old;
+            }
+
+            // value changed, write to save container
+            auto& saved = this->getSaveContainer();
             saved[key] = value;
             return old;
         }

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -243,7 +243,6 @@ namespace geode {
 
         matjson::Value& getSaveContainer();
         matjson::Value& getSaveContainerTemp();
-        matjson::Value& getSaveContainerDirty();
         matjson::Value const& getSaveContainerConst() const;
         matjson::Value& getSavedSettingsData();
 

--- a/loader/include/Geode/loader/Mod.hpp
+++ b/loader/include/Geode/loader/Mod.hpp
@@ -242,6 +242,8 @@ namespace geode {
         }
 
         matjson::Value& getSaveContainer();
+        matjson::Value& getSaveContainerTemp();
+        matjson::Value& getSaveContainerDirty();
         matjson::Value const& getSaveContainerConst() const;
         matjson::Value& getSavedSettingsData();
 
@@ -305,7 +307,7 @@ namespace geode {
                 return res.unwrap();
             }
 
-            auto savedMutable = this->getSaveContainer();
+            auto savedMutable = this->getSaveContainerTemp();
             savedMutable[key] = matjson::Value(defaultValue);
             return defaultValue;
         }

--- a/loader/include/Geode/loader/ModSettingsManager.hpp
+++ b/loader/include/Geode/loader/ModSettingsManager.hpp
@@ -16,8 +16,8 @@ namespace geode {
         friend class ::geode::Mod;
 
         void markRestartRequired();
-        void markDirty();
-        void unmarkDirty();
+        void queueSave();
+        void saveFinished();
 
     public:
         static ModSettingsManager* from(Mod* mod);
@@ -70,6 +70,6 @@ namespace geode {
          */
         void addDependant(Mod* mod);
 
-        bool dirty() const;
+        bool shouldSave() const;
     };
 }

--- a/loader/include/Geode/loader/ModSettingsManager.hpp
+++ b/loader/include/Geode/loader/ModSettingsManager.hpp
@@ -16,6 +16,8 @@ namespace geode {
         friend class ::geode::Mod;
 
         void markRestartRequired();
+        void markDirty();
+        void unmarkDirty();
 
     public:
         static ModSettingsManager* from(Mod* mod);
@@ -67,5 +69,7 @@ namespace geode {
          * for this mod, they are also reloaded for the dependant mods
          */
         void addDependant(Mod* mod);
+
+        bool dirty() const;
     };
 }

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -45,6 +45,10 @@ matjson::Value& Mod::getSaveContainer() {
     return m_impl->getSaveContainer();
 }
 
+matjson::Value const& Mod::getSaveContainerConst() const {
+    return m_impl->getSaveContainerConst();
+}
+
 matjson::Value& Mod::getSavedSettingsData() {
     return m_impl->m_settings->getSaveData();
 }

--- a/loader/src/loader/Mod.cpp
+++ b/loader/src/loader/Mod.cpp
@@ -45,6 +45,10 @@ matjson::Value& Mod::getSaveContainer() {
     return m_impl->getSaveContainer();
 }
 
+matjson::Value& Mod::getSaveContainerTemp() {
+    return m_impl->getSaveContainerTemp();
+}
+
 matjson::Value const& Mod::getSaveContainerConst() const {
     return m_impl->getSaveContainerConst();
 }

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -165,6 +165,12 @@ VersionInfo Mod::Impl::getVersion() const {
 }
 
 matjson::Value& Mod::Impl::getSaveContainer() {
+    m_savedDirty = true;
+
+    return m_saved;
+}
+
+matjson::Value const& Mod::Impl::getSaveContainerConst() const {
     return m_saved;
 }
 
@@ -252,9 +258,16 @@ Result<> Mod::Impl::saveData() {
     if (!res) {
         log::error("Unable to save settings: {}", res.unwrapErr());
     }
-    auto res2 = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());
-    if (!res2) {
-        log::error("Unable to save values: {}", res2.unwrapErr());
+
+    if(m_savedDirty) {
+        log::debug("Saving values for mod {}", m_metadata.getID());
+
+        auto res2 = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());
+        if (!res2) {
+            log::error("Unable to save values: {}", res2.unwrapErr());
+        }
+
+        // dirty flag shouldn't be reset because container can be retained by caller mod
     }
 
     return Ok();

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -215,11 +215,18 @@ Result<> Mod::Impl::loadData() {
     // Check if settings exist
     auto settingPath = m_saveDirPath / "settings.json";
     if (std::filesystem::exists(settingPath)) {
-        GEODE_UNWRAP_INTO(auto json, utils::file::readJson(settingPath));
-        auto load = m_settings->load(json);
-        if (!load) {
-            log::warn("Unable to load settings: {}", load.unwrapErr());
+        if(auto json = utils::file::readJson(settingPath)) {
+            auto load = m_settings->load(json.unwrap());
+            if (!load) {
+                log::warn("Unable to load settings: {}", load.unwrapErr());
+            }
+        } else {
+            // this used to early return but skipping saved values is not great behavior here imo
+            m_settings->markDirty();
+            log::warn("Unable to load settings: {}", json.unwrapErr());
         }
+    } else {
+        m_settings->markDirty();
     }
 
     // Saved values

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -290,9 +290,9 @@ Result<> Mod::Impl::saveData() {
     if (m_saveRequestState != SaveRequestState::Clean) {
         log::debug("Saving values for mod {}", m_metadata.getID());
 
-        auto res2 = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());
-        if (!res2) {
-            log::error("Unable to save values: {}", res2.unwrapErr());
+        auto res = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());
+        if (!res) {
+            log::error("Unable to save values: {}", res.unwrapErr());
         }
 
         if(m_saveRequestState == SaveRequestState::SaveOnce) {

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -192,7 +192,7 @@ bool Mod::Impl::needsEarlyLoad(std::vector<Mod*>& checked) const {
     checked.push_back(m_self);
     if (this->getMetadata().needsEarlyLoad()) return true;
     for (auto& dep : m_dependants) {
-        if(std::find(checked.begin(), checked.end(), dep) != checked.end()) continue;
+        if (std::find(checked.begin(), checked.end(), dep) != checked.end()) continue;
         if (dep->m_impl->needsEarlyLoad(checked)) return true;
     }
     return false;
@@ -221,7 +221,7 @@ Result<> Mod::Impl::loadData() {
     // Check if settings exist
     auto settingPath = m_saveDirPath / "settings.json";
     if (std::filesystem::exists(settingPath)) {
-        if(auto json = utils::file::readJson(settingPath)) {
+        if (auto json = utils::file::readJson(settingPath)) {
             auto load = m_settings->load(json.unwrap());
             if (!load) {
                 log::warn("Unable to load settings: {}", load.unwrapErr());
@@ -262,7 +262,7 @@ Result<> Mod::Impl::saveData() {
     }
 
     // ModSettingsManager keeps track of the whole savedata
-    if(m_settings->dirty()) {
+    if (m_settings->dirty()) {
         log::debug("Saving settings for mod {}", m_metadata.getID());
 
         matjson::Value json = m_settings->save();
@@ -281,7 +281,7 @@ Result<> Mod::Impl::saveData() {
         ModStateEvent(ModEventType::DataSaved, std::move(m_self)).send();
     }
 
-    if(m_savedTaken || m_savedDirty) {
+    if (m_savedTaken || m_savedDirty) {
         log::debug("Saving values for mod {}", m_metadata.getID());
 
         auto res2 = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -165,12 +165,16 @@ VersionInfo Mod::Impl::getVersion() const {
 }
 
 matjson::Value& Mod::Impl::getSaveContainer() {
+    // saved value taken, so we need to save it every time
+    // since we dont know what the caller will do with the container
     m_savedTaken = true;
 
     return m_saved;
 }
 
 matjson::Value& Mod::Impl::getSaveContainerTemp() {
+    // saved value dirty - caller promises to get rid
+    // of its ref before next save
     m_savedDirty = true;
 
     return m_saved;

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -249,14 +249,23 @@ Result<> Mod::Impl::saveData() {
     }
 
     // ModSettingsManager keeps track of the whole savedata
-    matjson::Value json = m_settings->save();
+    if(m_settings->dirty()) {
+        log::debug("Saving settings for mod {}", m_metadata.getID());
 
-    // saveData is expected to be synchronous, and always called from GD thread
-    ModStateEvent(ModEventType::DataSaved, std::move(m_self)).send();
+        matjson::Value json = m_settings->save();
 
-    auto res = utils::file::writeStringSafe(m_saveDirPath / "settings.json", json.dump());
-    if (!res) {
-        log::error("Unable to save settings: {}", res.unwrapErr());
+        // saveData is expected to be synchronous, and always called from GD thread
+        ModStateEvent(ModEventType::DataSaved, std::move(m_self)).send();
+
+        auto res = utils::file::writeStringSafe(m_saveDirPath / "settings.json", json.dump());
+        if (!res) {
+            log::error("Unable to save settings: {}", res.unwrapErr());
+        } else {
+            m_settings->unmarkDirty();
+        }
+    } else {
+        // duplicated line to retain old expectations of saveData being called after json dump but before file write
+        ModStateEvent(ModEventType::DataSaved, std::move(m_self)).send();
     }
 
     if(m_savedDirty) {

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -167,7 +167,7 @@ VersionInfo Mod::Impl::getVersion() const {
 matjson::Value& Mod::Impl::getSaveContainer() {
     // saved value taken, so we need to save it every time
     // since we dont know what the caller will do with the container
-    m_savedTaken = true;
+    m_saveRequestState = SaveRequestState::SaveUntilExit;
 
     return m_saved;
 }
@@ -175,7 +175,9 @@ matjson::Value& Mod::Impl::getSaveContainer() {
 matjson::Value& Mod::Impl::getSaveContainerTemp() {
     // saved value dirty - caller promises to get rid
     // of its ref before next save
-    m_savedDirty = true;
+    if(m_saveRequestState == SaveRequestState::Clean) {
+        m_saveRequestState = SaveRequestState::SaveOnce;
+    }
 
     return m_saved;
 }
@@ -232,11 +234,11 @@ Result<> Mod::Impl::loadData() {
             }
         } else {
             // this used to early return but skipping saved values is not great behavior here imo
-            m_settings->markDirty();
+            m_settings->queueSave();
             log::warn("Unable to load settings: {}", json.unwrapErr());
         }
     } else {
-        m_settings->markDirty();
+        m_settings->queueSave();
     }
 
     // Saved values
@@ -266,7 +268,7 @@ Result<> Mod::Impl::saveData() {
     }
 
     // ModSettingsManager keeps track of the whole savedata
-    if (m_settings->dirty()) {
+    if (m_settings->shouldSave()) {
         log::debug("Saving settings for mod {}", m_metadata.getID());
 
         matjson::Value json = m_settings->save();
@@ -278,14 +280,14 @@ Result<> Mod::Impl::saveData() {
         if (!res) {
             log::error("Unable to save settings: {}", res.unwrapErr());
         } else {
-            m_settings->unmarkDirty();
+            m_settings->saveFinished();
         }
     } else {
         // duplicated line to retain old expectations of saveData being called after json dump but before file write
         ModStateEvent(ModEventType::DataSaved, std::move(m_self)).send();
     }
 
-    if (m_savedTaken || m_savedDirty) {
+    if (m_saveRequestState != SaveRequestState::Clean) {
         log::debug("Saving values for mod {}", m_metadata.getID());
 
         auto res2 = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());
@@ -293,7 +295,9 @@ Result<> Mod::Impl::saveData() {
             log::error("Unable to save values: {}", res2.unwrapErr());
         }
 
-        m_savedDirty = false;
+        if(m_saveRequestState == SaveRequestState::SaveOnce) {
+            m_saveRequestState = SaveRequestState::Clean;
+        }
     }
 
     return Ok();

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -230,6 +230,7 @@ Result<> Mod::Impl::loadData() {
         if (auto json = utils::file::readJson(settingPath)) {
             auto load = m_settings->load(json.unwrap());
             if (!load) {
+                m_settings->queueSave();
                 log::warn("Unable to load settings: {}", load.unwrapErr());
             }
         } else {

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -165,6 +165,12 @@ VersionInfo Mod::Impl::getVersion() const {
 }
 
 matjson::Value& Mod::Impl::getSaveContainer() {
+    m_savedTaken = true;
+
+    return m_saved;
+}
+
+matjson::Value& Mod::Impl::getSaveContainerTemp() {
     m_savedDirty = true;
 
     return m_saved;
@@ -275,7 +281,7 @@ Result<> Mod::Impl::saveData() {
         ModStateEvent(ModEventType::DataSaved, std::move(m_self)).send();
     }
 
-    if(m_savedDirty) {
+    if(m_savedTaken || m_savedDirty) {
         log::debug("Saving values for mod {}", m_metadata.getID());
 
         auto res2 = utils::file::writeStringSafe(m_saveDirPath / "saved.json", m_saved.dump());
@@ -283,7 +289,7 @@ Result<> Mod::Impl::saveData() {
             log::error("Unable to save values: {}", res2.unwrapErr());
         }
 
-        // dirty flag shouldn't be reset because container can be retained by caller mod
+        m_savedDirty = false;
     }
 
     return Ok();

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -8,6 +8,12 @@
 #include <Geode/loader/Signal.hpp>
 
 namespace geode {
+    enum class SaveRequestState {
+        Clean,
+        SaveOnce,
+        SaveUntilExit,
+    };
+
     class Mod::Impl {
     public:
         Mod* m_self;
@@ -53,12 +59,7 @@ namespace geode {
          * Whether the saved values need to be saved to disk one time
          * (container dirty)
          */
-        bool m_savedDirty = false;
-        /**
-         * Whether the saved values need to be always re-saved until game exit
-         * (container taken by a mod)
-         */
-        bool m_savedTaken = false;
+        SaveRequestState m_saveRequestState = SaveRequestState::Clean;
         /**
          * Setting values. This is behind unique_ptr for interior mutability
          */

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -49,6 +49,7 @@ namespace geode {
          * Saved values
          */
         matjson::Value m_saved = matjson::Value();
+        bool m_savedDirty = false;
         /**
          * Setting values. This is behind unique_ptr for interior mutability
          */
@@ -105,6 +106,7 @@ namespace geode {
         bool isEphemeral() const;
 
         matjson::Value& getSaveContainer();
+        matjson::Value const& getSaveContainerConst() const;
 
 #if defined(GEODE_EXPOSE_SECRET_INTERNALS_IN_HEADERS_DO_NOT_DEFINE_PLEASE)
         void setMetadata(ModMetadata const& metadata);

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -49,7 +49,15 @@ namespace geode {
          * Saved values
          */
         matjson::Value m_saved = matjson::Value();
+        /**
+         * Whether the saved values need to be saved to disk one time
+         * (container dirty)
+         */
         bool m_savedDirty = false;
+        /**
+         * Whether the saved values need to be always re-saved until game exit
+         * (container taken by a mod)
+         */
         bool m_savedTaken = false;
         /**
          * Setting values. This is behind unique_ptr for interior mutability

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -50,6 +50,7 @@ namespace geode {
          */
         matjson::Value m_saved = matjson::Value();
         bool m_savedDirty = false;
+        bool m_savedTaken = false;
         /**
          * Setting values. This is behind unique_ptr for interior mutability
          */
@@ -106,6 +107,7 @@ namespace geode {
         bool isEphemeral() const;
 
         matjson::Value& getSaveContainer();
+        matjson::Value& getSaveContainerTemp();
         matjson::Value const& getSaveContainerConst() const;
 
 #if defined(GEODE_EXPOSE_SECRET_INTERNALS_IN_HEADERS_DO_NOT_DEFINE_PLEASE)

--- a/loader/src/loader/ModSettingsManager.cpp
+++ b/loader/src/loader/ModSettingsManager.cpp
@@ -188,8 +188,7 @@ public:
     // update this by calling saveSettingValueToSave
     matjson::Value savedata;
     bool restartRequired = false;
-    bool dirty = false;
-    bool taken = false;
+    SaveRequestState saveRequestState = SaveRequestState::Clean;
 
     bool loadSettingValueFromSave(std::string const& key) {
         if (this->savedata.contains(key) && this->settings.contains(key)) {
@@ -209,7 +208,9 @@ public:
         else {
             if (!this->savedata.contains(key)) {
                 log::error("Unable to load setting '{}' for mod {} (not found in savedata)", key, this->modID);
-                dirty = true;
+                if(saveRequestState == SaveRequestState::Clean) {
+                    saveRequestState = SaveRequestState::SaveOnce;
+                }
             }
             return false;
         }
@@ -288,16 +289,20 @@ void ModSettingsManager::markRestartRequired() {
     m_impl->restartRequired = true;
 }
 
-void ModSettingsManager::markDirty() {
-    m_impl->dirty = true;
+void ModSettingsManager::queueSave() {
+    if(m_impl->saveRequestState == SaveRequestState::Clean) {
+        m_impl->saveRequestState = SaveRequestState::SaveOnce;
+    }
 }
 
-void ModSettingsManager::unmarkDirty() {
-    m_impl->dirty = false;
+void ModSettingsManager::saveFinished() {
+    if(m_impl->saveRequestState == SaveRequestState::SaveOnce) {
+        m_impl->saveRequestState = SaveRequestState::Clean;
+    }
 }
 
-bool ModSettingsManager::dirty() const {
-    return m_impl->dirty || m_impl->taken;
+bool ModSettingsManager::shouldSave() const {
+    return m_impl->saveRequestState != SaveRequestState::Clean;
 }
 
 Result<> ModSettingsManager::registerCustomSettingType(std::string_view type, SettingGenerator generator) {
@@ -334,7 +339,7 @@ Result<> ModSettingsManager::load(matjson::Value const& json) {
         for (auto const& [key, _] : m_impl->settings) {
             if (!json.contains(key)) {
                 log::error("Unable to load setting '{}' for mod {} (not found in savedata)", key, m_impl->modID);
-                m_impl->dirty = true;
+                this->queueSave();
                 break;
             }
         }
@@ -351,7 +356,7 @@ matjson::Value ModSettingsManager::save() {
 }
 
 matjson::Value& ModSettingsManager::getSaveData() {
-    m_impl->taken = true;
+    m_impl->saveRequestState = SaveRequestState::SaveUntilExit;
 
     return m_impl->savedata;
 }

--- a/loader/src/loader/ModSettingsManager.cpp
+++ b/loader/src/loader/ModSettingsManager.cpp
@@ -189,6 +189,7 @@ public:
     matjson::Value savedata;
     bool restartRequired = false;
     bool dirty = false;
+    bool taken = false;
 
     bool loadSettingValueFromSave(std::string const& key) {
         if (this->savedata.contains(key) && this->settings.contains(key)) {
@@ -350,6 +351,8 @@ matjson::Value ModSettingsManager::save() {
 }
 
 matjson::Value& ModSettingsManager::getSaveData() {
+    m_impl->taken = true;
+
     return m_impl->savedata;
 }
 

--- a/loader/src/loader/ModSettingsManager.cpp
+++ b/loader/src/loader/ModSettingsManager.cpp
@@ -297,7 +297,7 @@ void ModSettingsManager::unmarkDirty() {
 }
 
 bool ModSettingsManager::dirty() const {
-    return m_impl->dirty;
+    return m_impl->dirty || m_impl->taken;
 }
 
 Result<> ModSettingsManager::registerCustomSettingType(std::string_view type, SettingGenerator generator) {

--- a/loader/src/loader/ModSettingsManager.cpp
+++ b/loader/src/loader/ModSettingsManager.cpp
@@ -207,7 +207,7 @@ public:
             return true;
         }
         else {
-            if(!this->savedata.contains(key)) {
+            if (!this->savedata.contains(key)) {
                 log::error("Unable to load setting '{}' for mod {} (not found in savedata)", key, this->modID);
                 dirty = true;
             }
@@ -332,7 +332,7 @@ Result<> ModSettingsManager::load(matjson::Value const& json) {
         }
 
         for (auto const& [key, _] : m_impl->settings) {
-            if(!json.contains(key)) {
+            if (!json.contains(key)) {
                 log::error("Unable to load setting '{}' for mod {} (not found in savedata)", key, m_impl->modID);
                 m_impl->dirty = true;
                 break;

--- a/loader/src/loader/ModSettingsManager.cpp
+++ b/loader/src/loader/ModSettingsManager.cpp
@@ -188,6 +188,7 @@ public:
     // update this by calling saveSettingValueToSave
     matjson::Value savedata;
     bool restartRequired = false;
+    bool dirty = false;
 
     bool loadSettingValueFromSave(std::string const& key) {
         if (this->savedata.contains(key) && this->settings.contains(key)) {
@@ -278,6 +279,18 @@ ModSettingsManager::ModSettingsManager(ModSettingsManager&&) noexcept = default;
 
 void ModSettingsManager::markRestartRequired() {
     m_impl->restartRequired = true;
+}
+
+void ModSettingsManager::markDirty() {
+    m_impl->dirty = true;
+}
+
+void ModSettingsManager::unmarkDirty() {
+    m_impl->dirty = false;
+}
+
+bool ModSettingsManager::dirty() const {
+    return m_impl->dirty;
 }
 
 Result<> ModSettingsManager::registerCustomSettingType(std::string_view type, SettingGenerator generator) {

--- a/loader/src/loader/ModSettingsManager.cpp
+++ b/loader/src/loader/ModSettingsManager.cpp
@@ -206,6 +206,10 @@ public:
             return true;
         }
         else {
+            if(!this->savedata.contains(key)) {
+                log::error("Unable to load setting '{}' for mod {} (not found in savedata)", key, this->modID);
+                dirty = true;
+            }
             return false;
         }
     }
@@ -238,7 +242,9 @@ public:
             }
             if (auto v3 = (*gen)(key, modID, setting.json)) {
                 setting.v3 = v3.unwrap();
-                this->loadSettingValueFromSave(key);
+
+                // the loading is unnecessary, m_saveData is not initialized yet
+                // this->loadSettingValueFromSave(key);
             }
             else {
                 log::error(
@@ -321,6 +327,14 @@ Result<> ModSettingsManager::load(matjson::Value const& json) {
                         }
                     }
                 }
+            }
+        }
+
+        for (auto const& [key, _] : m_impl->settings) {
+            if(!json.contains(key)) {
+                log::error("Unable to load setting '{}' for mod {} (not found in savedata)", key, m_impl->modID);
+                m_impl->dirty = true;
+                break;
             }
         }
     }

--- a/loader/src/loader/SettingV3.cpp
+++ b/loader/src/loader/SettingV3.cpp
@@ -575,10 +575,10 @@ Mod* SettingV3::getMod() const {
 
 void SettingV3::markChanged() {
     auto manager = ModSettingsManager::from(this->getMod());
-    if (m_impl->requiresRestart) {
-        manager->markRestartRequired();
-    }
-    if(manager) {
+    if (manager) {
+        if (m_impl->requiresRestart) {
+            manager->markRestartRequired();
+        }
         manager->markDirty();
     }
     SettingChangedEventV3(this->getModID(), this->getKey()).send(shared_from_this());

--- a/loader/src/loader/SettingV3.cpp
+++ b/loader/src/loader/SettingV3.cpp
@@ -579,7 +579,7 @@ void SettingV3::markChanged() {
         if (m_impl->requiresRestart) {
             manager->markRestartRequired();
         }
-        manager->markDirty();
+        manager->queueSave();
     }
     SettingChangedEventV3(this->getModID(), this->getKey()).send(shared_from_this());
 }

--- a/loader/src/loader/SettingV3.cpp
+++ b/loader/src/loader/SettingV3.cpp
@@ -578,6 +578,9 @@ void SettingV3::markChanged() {
     if (m_impl->requiresRestart) {
         manager->markRestartRequired();
     }
+    if(manager) {
+        manager->markDirty();
+    }
     SettingChangedEventV3(this->getModID(), this->getKey()).send(shared_from_this());
 }
 class TitleSettingV3::Impl final {

--- a/loader/src/ui/mods/settings/ModSettingsPopup.cpp
+++ b/loader/src/ui/mods/settings/ModSettingsPopup.cpp
@@ -71,7 +71,7 @@ void ModSettingsPopup::updateState(SettingNode* invoker) {
 
     // frame delay for debounce (avoids repeating save for every changed setting)
     Loader::get()->queueInMainThread([mod = m_mod, manager] {
-        if (manager->dirty()) {
+        if (manager->shouldSave()) {
             (void) mod->saveData();
         }
     });

--- a/loader/src/ui/mods/settings/ModSettingsPopup.cpp
+++ b/loader/src/ui/mods/settings/ModSettingsPopup.cpp
@@ -65,7 +65,16 @@ bool ModSettingsPopup::init(Mod* mod, bool forceDisableTheme) {
 
 void ModSettingsPopup::updateState(SettingNode* invoker) {
     BaseSettingsPopup::updateState(invoker);
-    m_restartBtn->setVisible(ModSettingsManager::from(m_mod)->restartRequired());
+
+    auto manager = ModSettingsManager::from(m_mod);
+    m_restartBtn->setVisible(manager->restartRequired());
+
+    // frame delay for debounce (avoids repeating save for every changed setting)
+    Loader::get()->queueInMainThread([mod = m_mod, manager] {
+        if (manager->dirty()) {
+            (void) mod->saveData();
+        }
+    });
 }
 
 void ModSettingsPopup::onOpenSaveDirectory(CCObject*) {


### PR DESCRIPTION
Draft for now, since I see some space for improvements, but already creating the PR to get a second pair of eyes on this so I can see if this approach is worth pursuing.

This PR supersedes #1952. It adds "dirty" and "taken" flag tracking to saved and settings jsons and avoids saving them. As mentioned before, the motivation is primarily Android saving performance, though this leads to measurable improvements on Windows as well.

The idea is simple - do not resave settings and saved jsons if they haven't changed. To achieve this it essentially tracks 3 states - clean, dirty, taken. Clean is simple - do not save. Dirty means that it should be saved the next time the game saves but it doesn't need to be saved again afterwards. Taken means that a ref to the container may be stored somewhere, so it should be resaved every time until game exit. This logic is applied to both settings and saved values. Dirty flag is also set if the mod contains settings the user does not have or if the settings file is corrupted (didn't successfully load) for some reason.

In addition to this major change, the PR contains the following minor changes:
- Mod settings are now saved when the user clicks "Apply" in the mod settings popup (to save time on game exit)
- Saved values are now loaded even if settings fail to load

Stuff I'd like to figure out before marking this prod ready
- Using RAII to track container borrow lifespans to not require a permanent taken flag (might not be doable without V6 though?)
- probs just that, i also need to write doc comments and maybe reorder the members i added

thanks for reading my big yap