### PR TITLE
fix(utils): reject trailing characters in numFromString

### DIFF
--- a/loader/src/utils/general.cpp
+++ b/loader/src/utils/general.cpp
@@ -18,7 +18,7 @@ static Result<T> toParseResult(T* value, fast_float::from_chars_result res, std:
     if (ec == std::errc::result_out_of_range) return Err("Number is out of range for target type");
     if (ec != std::errc()) return Err(std::make_error_code(ec).message());
 
-    if (ptr != str.data() + str.size()) return Err("String contains trailing extra data");
+    if (ptr != str.data() + str.size()) return Err("String contains trailing data");
 
     return Ok(*value);
 }

--- a/loader/src/utils/general.cpp
+++ b/loader/src/utils/general.cpp
@@ -13,13 +13,15 @@ float geode::utils::getDisplayFactor() {
 template <typename T>
 static Result<T> toParseResult(T* value, fast_float::from_chars_result res, std::string_view str) {
     auto [ptr, ec] = res;
-    if (ec == std::errc()) return Ok(*value);
-    else if (ptr != str.data() + str.size()) return Err("String contains trailing extra data");
-    else if (ec == std::errc::invalid_argument) return Err("String is not a number");
-    else if (ec == std::errc::result_out_of_range) return Err("Number is out of range for target type");
-    else return Err("Unknown error");
-}
 
+    if (ec == std::errc::invalid_argument) return Err("String is not a number");
+    if (ec == std::errc::result_out_of_range) return Err("Number is out of range for target type");
+    if (ec != std::errc()) return Err("Unknown error");
+
+    if (ptr != str.data() + str.size()) return Err("String contains trailing extra data");
+
+    return Ok(*value);
+}
 template <typename T>
 static Result<T> parseFloat(std::string_view str) {
     T result;

--- a/loader/src/utils/general.cpp
+++ b/loader/src/utils/general.cpp
@@ -16,12 +16,13 @@ static Result<T> toParseResult(T* value, fast_float::from_chars_result res, std:
 
     if (ec == std::errc::invalid_argument) return Err("String is not a number");
     if (ec == std::errc::result_out_of_range) return Err("Number is out of range for target type");
-    if (ec != std::errc()) return Err("Unknown error");
+    if (ec != std::errc()) return Err(std::make_error_code(ec).message());
 
     if (ptr != str.data() + str.size()) return Err("String contains trailing extra data");
 
     return Ok(*value);
 }
+
 template <typename T>
 static Result<T> parseFloat(std::string_view str) {
     T result;


### PR DESCRIPTION
this PR is dedicated to ery

- fixes a bug where numFromString returned an Ok for strings containing valid numeric prefixes followed by unparsed trailing characters
- returns the message of the error code instead of returning "Unknown error"
- trailing data error returns "String contains trailing data" instead of "String contains trailing extra data" (extra is unnecessary here imo) 

see the screenshots for reference

<img width="2892" height="620" alt="Screenshot_2026-08-23_at_7 19 35_AM" src="https://github.com/user-attachments/assets/f08b5592-0287-44aa-aa74-e35a5b6f51ed" />
<img width="4056" height="452" alt="Screenshot_2026-08-23_at_7 19 55_AM" src="https://github.com/user-attachments/assets/f88bae52-1a61-4f1f-b809-69bd3d7e7ff6" />
