### PR TITLE
fix native dependency binary loading

### DIFF
--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -541,6 +541,7 @@ void Loader::Impl::loadModGraph(Mod* node, bool early) {
 
     auto loadFunction = [this, node, early]() {
         if (node->shouldLoad()) {
+            node->m_impl->loadNativeModBinaries();
             log::debug("Loading binary");
             auto res = node->m_impl->loadBinary();
             if (!res) {

--- a/loader/src/loader/LoaderImpl.hpp
+++ b/loader/src/loader/LoaderImpl.hpp
@@ -89,7 +89,6 @@ namespace geode {
 
         void updateModResources(Mod* mod);
         void addSearchPaths();
-        void addNativeBinariesPath(std::filesystem::path const& path);
 
         Result<> setup();
         void forceReset();

--- a/loader/src/loader/ModImpl.cpp
+++ b/loader/src/loader/ModImpl.cpp
@@ -79,16 +79,6 @@ Result<> Mod::Impl::setup() {
             CCFileUtils::get()->addSearchPath(utils::string::pathToString(searchPathRoot).c_str());
         });
 
-        // binaries on macos are merged, so make the platform binaries merged as well
-        auto const binaryPlatformId = PlatformID::toShortString(GEODE_PLATFORM_TARGET GEODE_MACOS(, true));
-
-        auto const binariesDir = searchPathRoot / m_metadata.getID() / "binaries" / binaryPlatformId;
-
-        std::error_code code;
-        if (std::filesystem::exists(binariesDir, code) && !code) {
-            LoaderImpl::get()->addNativeBinariesPath(binariesDir);
-        }
-
         m_resourcesLoaded = true;
     }
 
@@ -716,6 +706,21 @@ bool Mod::Impl::isPinned() const {
 
 void Mod::Impl::setPinned(bool pinned) {
     Mod::get()->setSavedValue<bool>("is-pinned-" + m_metadata.getID(), pinned);
+}
+
+void Mod::Impl::loadNativeModBinaries() {
+    auto searchPathRoot = dirs::getModRuntimeDir() / m_metadata.getID() / "resources";
+
+    // binaries on macos are merged, so make the platform binaries merged as well
+    auto const binaryPlatformId = PlatformID::toShortString(GEODE_PLATFORM_TARGET GEODE_MACOS(, true));
+
+    auto const binariesDir = searchPathRoot / m_metadata.getID() / "binaries" / binaryPlatformId;
+
+    std::error_code code;
+    if (std::filesystem::exists(binariesDir, code) && !code) {
+        geode::log::info("Loaded binaries from path {}", binariesDir);
+        ModImpl::get()->addNativeBinariesPath(binariesDir);
+    }
 }
 
 static Result<ModMetadata> getModImplInfo() {

--- a/loader/src/loader/ModImpl.hpp
+++ b/loader/src/loader/ModImpl.hpp
@@ -168,6 +168,10 @@ namespace geode {
 
         bool isPinned() const;
         void setPinned(bool pinned);
+
+        // native binary loading
+        void addNativeBinariesPath(std::filesystem::path const& path);
+        void loadNativeModBinaries();
     };
 
     class ModImpl : public Mod::Impl {

--- a/loader/src/platform/android/LoaderImpl.cpp
+++ b/loader/src/platform/android/LoaderImpl.cpp
@@ -57,10 +57,6 @@ bool Loader::Impl::userTriedToLoadDLLs() const {
     return false;
 }
 
-void Loader::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
-    log::warn("LoaderImpl::addNativeBinariesPath not implement on this platform, not adding path {}", path);
-}
-
 bool Loader::Impl::supportsLaunchArguments() const {
     return true;
 }

--- a/loader/src/platform/android/ModImpl.cpp
+++ b/loader/src/platform/android/ModImpl.cpp
@@ -39,3 +39,7 @@ Result<> Mod::Impl::loadPlatformBinary() {
     log::error("Unable to load the SO: dlerror returned ({})", err);
     return Err("Unable to load the SO: dlerror returned (" + err + ")");
 }
+
+void Mod::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
+    log::warn("LoaderImpl::addNativeBinariesPath not implement on this platform, not adding path {}", path);
+}

--- a/loader/src/platform/ios/LoaderImpl.mm
+++ b/loader/src/platform/ios/LoaderImpl.mm
@@ -91,10 +91,6 @@ std::string Loader::Impl::getLaunchCommand() const {
     return (getenv("LAUNCHARGS")) ? getenv("LAUNCHARGS") : std::string();
 }
 
-void Loader::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
-    log::warn("LoaderImpl::addNativeBinariesPath not implement on this platform, not adding path {}", path);
-}
-
 std::string Loader::Impl::getGameVersion() {
     NSBundle* mainBundle = [NSBundle mainBundle];
     NSDictionary* infoDictionary = [mainBundle infoDictionary];

--- a/loader/src/platform/ios/ModImpl.cpp
+++ b/loader/src/platform/ios/ModImpl.cpp
@@ -39,3 +39,7 @@ Result<> Mod::Impl::loadPlatformBinary() {
     std::string err = (char const*)dlerror();
     return Err("Unable to load the DYLIB: dlerror returned (" + err + ")");
 }
+
+void Mod::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
+    log::warn("LoaderImpl::addNativeBinariesPath not implement on this platform, not adding path {}", path);
+}

--- a/loader/src/platform/mac/LoaderImpl.mm
+++ b/loader/src/platform/mac/LoaderImpl.mm
@@ -179,36 +179,6 @@ bool Loader::Impl::userTriedToLoadDLLs() const {
     return false;
 }
 
-void Loader::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
-    // this takes advantage of dyld using already loaded binaries when loading relative shared libraries
-    // however, this also means that the binaries are loaded, which could have some weird side effects
-    // but if you could use dlopen (and thus control when libraries are loaded), then you wouldn't be using this, would you?
-
-    for (const auto& entry : std::filesystem::directory_iterator(path)) {
-        if (!entry.is_regular_file()) {
-            continue;
-        }
-
-        auto& entry_path = entry.path();
-
-        if (entry_path.extension() != ".dylib") {
-            continue;
-        }
-
-        auto handle = dlopen(utils::string::pathToString(entry_path).c_str(), RTLD_LAZY);
-
-        if (!handle) {
-            auto err = dlerror();
-            log::warn("failed to load native binary at {}: dlerror returned ({})", 
-                entry_path, err
-            );
-            continue;
-        }
-
-        dlclose(handle);
-    }
-}
-
 bool gameVersionIsAmbiguous(std::string gameVersion) {
     return gameVersion == "2.207" || gameVersion == "2.208";
 }

--- a/loader/src/platform/mac/ModImpl.cpp
+++ b/loader/src/platform/mac/ModImpl.cpp
@@ -39,3 +39,33 @@ Result<> Mod::Impl::loadPlatformBinary() {
     std::string err = (char const*)dlerror();
     return Err("Unable to load the DYLIB: dlerror returned (" + err + ")");
 }
+
+void Mod::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
+    // this takes advantage of dyld using already loaded binaries when loading relative shared libraries
+    // however, this also means that the binaries are loaded, which could have some weird side effects
+    // but if you could use dlopen (and thus control when libraries are loaded), then you wouldn't be using this, would you?
+
+    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+
+        auto& entry_path = entry.path();
+
+        if (entry_path.extension() != ".dylib") {
+            continue;
+        }
+
+        auto handle = dlopen(utils::string::pathToString(entry_path).c_str(), RTLD_LAZY);
+
+        if (!handle) {
+            auto err = dlerror();
+            log::warn("failed to load native binary at {}: dlerror returned ({})", 
+                entry_path, err
+            );
+            continue;
+        }
+
+        dlclose(handle);
+    }
+}

--- a/loader/src/platform/windows/LoaderImpl.cpp
+++ b/loader/src/platform/windows/LoaderImpl.cpp
@@ -80,15 +80,6 @@ bool Loader::Impl::userTriedToLoadDLLs() const {
     return triedToLoadDLLs;
 }
 
-void Loader::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
-    // https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory#remarks
-    static auto runOnce = [] {
-        SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-        return 0;
-    }();
-    AddDllDirectory(path.c_str());
-}
-
 bool Loader::Impl::supportsLaunchArguments() const {
     return true;
 }

--- a/loader/src/platform/windows/ModImpl.cpp
+++ b/loader/src/platform/windows/ModImpl.cpp
@@ -90,3 +90,12 @@ Result<> Mod::Impl::loadPlatformBinary() {
     }
     return Err("Unable to load the DLL: " + getLastWinError());
 }
+
+void Mod::Impl::addNativeBinariesPath(std::filesystem::path const& path) {
+    // https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory#remarks
+    static auto runOnce = [] {
+        SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+        return 0;
+    }();
+    AddDllDirectory(path.c_str());
+}


### PR DESCRIPTION
* fixes a bug where if a mod has native binary dependencies as part of its resources the game would needed to be restarted twice after install due to searching binary paths too late
* moves addNativeBinariesPath to Mod::Impl and refactors native binary loading to new member function Mod::Impl::loadNativeModBinaries for clarity