### PR TITLE
geode::Toggler

### DIFF
--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Geode/utils/ZStringView.hpp>
+#include <Geode/utils/function.hpp>
 #include <cocos2d.h>
 
 namespace geode {
@@ -108,7 +109,7 @@ namespace geode {
         int getTouchPriority();
 
         /**
-         * Set the touch multiplier, which increases the distance from the 
+         * Set the touch multiplier, which increases the distance from the
          * center that the button can be pressed (default is 1)
          */
         void setTouchMultiplier(float multipler);
@@ -145,7 +146,7 @@ namespace geode {
          */
         virtual void setEnabled(bool enabled);
         virtual bool isEnabled();
-        
+
         /**
          * Get the selected state of the button
          */
@@ -208,7 +209,7 @@ namespace geode {
          * Unregister a button (must be called in onExit)
          */
         void unregisterButton(Button* button);
-        
+
         /**
          * Pass moves from ccTouchMoved to all buttons sharing a parent
          */

--- a/loader/include/Geode/ui/Toggler.hpp
+++ b/loader/include/Geode/ui/Toggler.hpp
@@ -36,21 +36,27 @@ namespace geode {
             TogglerCallback toggleCallback = nullptr
         );
 
-        /// Make a toggle with GD's checkbox sprites.
+        /// Make a toggle with GD's standard checkbox sprites.
         ///
         /// @param toggleCallback Called when the toggle changes.
-        /// @param scale Checkbox scale.
         ///
         /// @example
         /// auto toggler = Toggler::createWithStandardSprites(
         ///     [](Toggler* sender, bool isToggled) {
         ///         log::info("Checkbox: {}", isToggled);
-        ///     },
-        ///     0.8f
+        ///     }
         /// );
         static Toggler* createWithStandardSprites(
-            TogglerCallback toggleCallback = nullptr,
-            float scale = 1.0f
+            TogglerCallback toggleCallback = nullptr
+        );
+
+        /// Make a toggle with GD's standard checkbox sprites.
+        ///
+        /// @param scale Checkbox scale.
+        /// @param toggleCallback Called when the toggle changes.
+        static Toggler* createWithStandardSprites(
+            float scale,
+            TogglerCallback toggleCallback = nullptr
         );
 
         /// Make a toggle using sprites from files.
@@ -58,7 +64,6 @@ namespace geode {
         /// @param offFileName Sprite shown when off.
         /// @param onFileName Sprite shown when on.
         /// @param toggleCallback Called when the toggle changes.
-        /// @param scale Sprite scale.
         ///
         /// @example
         /// auto toggler = Toggler::createWithSprites(
@@ -66,14 +71,25 @@ namespace geode {
         ///     "on.png"_spr,
         ///     [](Toggler* sender, bool isToggled) {
         ///         log::info("Custom toggle: {}", isToggled);
-        ///     },
-        ///     1.25f
+        ///     }
         /// );
         static Toggler* createWithSprites(
             geode::ZStringView offFileName,
             geode::ZStringView onFileName,
-            TogglerCallback toggleCallback = nullptr,
-            float scale = 1.0f
+            TogglerCallback toggleCallback = nullptr
+        );
+
+        /// Make a toggle using sprites from files.
+        ///
+        /// @param offFileName Sprite shown when off.
+        /// @param onFileName Sprite shown when on.
+        /// @param scale Sprite scale.
+        /// @param toggleCallback Called when the toggle changes.
+        static Toggler* createWithSprites(
+            geode::ZStringView offFileName,
+            geode::ZStringView onFileName,
+            float scale,
+            TogglerCallback toggleCallback = nullptr
         );
 
         /// Make a toggle using sprites from a sprite sheet.
@@ -81,7 +97,6 @@ namespace geode {
         /// @param offFrameName Frame shown when off.
         /// @param onFrameName Frame shown when on.
         /// @param toggleCallback Called when the toggle changes.
-        /// @param scale Sprite scale.
         ///
         /// @example
         /// auto toggler = Toggler::createWithSpriteFrameNames(
@@ -94,92 +109,62 @@ namespace geode {
         static Toggler* createWithSpriteFrameNames(
             geode::ZStringView offFrameName,
             geode::ZStringView onFrameName,
-            TogglerCallback toggleCallback = nullptr,
-            float scale = 1.0f
+            TogglerCallback toggleCallback = nullptr
+        );
+
+        /// Make a toggle using sprites from a sprite sheet.
+        ///
+        /// @param offFrameName Frame shown when off.
+        /// @param onFrameName Frame shown when on.
+        /// @param scale Sprite scale.
+        /// @param toggleCallback Called when the toggle changes.
+        static Toggler* createWithSpriteFrameNames(
+            geode::ZStringView offFrameName,
+            geode::ZStringView onFrameName,
+            float scale,
+            TogglerCallback toggleCallback = nullptr
         );
 
         /// Check if the toggle is on.
-        ///
-        /// @example
-        /// if (toggler->isToggled()) {
-        ///     log::info("Toggle is enabled");
-        /// }
         bool isToggled() const;
 
         /// Set whether the toggle is on.
         ///
         /// @param toggled Whether the toggle should be on.
-        /// @param triggerCallback Whether to call the toggle callback.
-        ///
-        /// @example
-        /// toggler->setToggled(true);
-        ///
-        /// // Change the state without calling the callback.
-        /// toggler->setToggled(false, false);
+        /// @param triggerCallback Whether to trigger the callback if the state changes.
         void setToggled(bool toggled, bool triggerCallback = false);
 
         /// Toggle between the on and off states.
         ///
-        /// @param triggerCallback Whether to call the toggle callback.
-        ///
-        /// @example
-        /// toggler->toggle();
-        ///
-        /// // Toggle without calling the callback.
-        /// toggler->toggle(false);
+        /// @param triggerCallback Whether to trigger the callback.
         void toggle(bool triggerCallback = true);
 
         /// Get the node shown when the toggle is off.
-        ///
-        /// @example
-        /// auto offNode = toggler->getOffNode();
-        /// offNode->setOpacity(200);
         cocos2d::CCNode* getOffNode() const;
 
         /// Change the node shown when the toggle is off.
         ///
-        /// @param node New off node.
-        ///
-        /// @example
-        /// auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
-        /// toggler->setOffNode(offNode);
+        /// @param node Node to show when off.
         void setOffNode(cocos2d::CCNode* node);
 
         /// Get the node shown when the toggle is on.
-        ///
-        /// @example
-        /// auto onNode = toggler->getOnNode();
-        /// onNode->setScale(0.8f);
         cocos2d::CCNode* getOnNode() const;
 
         /// Change the node shown when the toggle is on.
         ///
-        /// @param node New on node.
-        ///
-        /// @example
-        /// auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
-        /// toggler->setOnNode(onNode);
+        /// @param node Node to show when on.
         void setOnNode(cocos2d::CCNode* node);
 
         /// Change the callback.
         ///
-        /// @param callback New callback.
-        ///
-        /// @example
-        /// toggler->setToggleCallback([](Toggler* sender, bool isToggled) {
-        ///     if (isToggled) {
-        ///         log::info("Enabled");
-        ///     } else {
-        ///         log::info("Disabled");
-        ///     }
-        /// });
+        /// @param callback Callback to trigger when the toggle changes.
         void setToggleCallback(TogglerCallback callback);
 
-        virtual void activate() override;
+        void activate() override;
 
     protected:
         Toggler();
-        virtual ~Toggler();
+        ~Toggler();
 
         bool init(
             cocos2d::CCNode* offNode,

--- a/loader/include/Geode/ui/Toggler.hpp
+++ b/loader/include/Geode/ui/Toggler.hpp
@@ -18,11 +18,9 @@ namespace geode {
         /// @param toggleCallback Called when the toggle changes.
         ///
         /// @example
-        /// ```
         /// auto toggler = Toggler::create([](Toggler* sender, bool isToggled) {
         ///     log::info("Toggled: {}", isToggled);
         /// });
-        /// ```
         static Toggler* create(TogglerCallback toggleCallback = nullptr);
 
         /// Make a toggle with custom on/off nodes.
@@ -32,7 +30,6 @@ namespace geode {
         /// @param toggleCallback Called when the toggle changes.
         ///
         /// @example
-        /// ```
         /// auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
         /// auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
         ///
@@ -43,7 +40,6 @@ namespace geode {
         ///         log::info("Toggled: {}", isToggled);
         ///     }
         /// );
-        /// ```
         static Toggler* createWithNodes(
             cocos2d::CCNode* offNode,
             cocos2d::CCNode* onNode,
@@ -56,14 +52,12 @@ namespace geode {
         /// @param scale Checkbox scale.
         ///
         /// @example
-        /// ```
         /// auto toggler = Toggler::createWithStandardSprites(
         ///     [](Toggler* sender, bool isToggled) {
         ///         log::info("Checkbox: {}", isToggled);
         ///     },
         ///     0.8f
         /// );
-        /// ```
         static Toggler* createWithStandardSprites(
             TogglerCallback toggleCallback = nullptr,
             float scale = 1.0f
@@ -77,7 +71,6 @@ namespace geode {
         /// @param scale Sprite scale.
         ///
         /// @example
-        /// ```
         /// auto toggler = Toggler::createWithSprites(
         ///     "off.png"_spr,
         ///     "on.png"_spr,
@@ -86,7 +79,6 @@ namespace geode {
         ///     },
         ///     1.25f
         /// );
-        /// ```
         static Toggler* createWithSprites(
             geode::ZStringView offFileName,
             geode::ZStringView onFileName,
@@ -102,7 +94,6 @@ namespace geode {
         /// @param scale Sprite scale.
         ///
         /// @example
-        /// ```
         /// auto toggler = Toggler::createWithSpriteFrameNames(
         ///     "GJ_checkOff_001.png"_spr,
         ///     "GJ_checkOn_001.png"_spr,
@@ -110,7 +101,6 @@ namespace geode {
         ///         log::info("Checkbox state changed: {}", isToggled);
         ///     }
         /// );
-        /// ```
         static Toggler* createWithSpriteFrameNames(
             geode::ZStringView offFrameName,
             geode::ZStringView onFrameName,
@@ -121,11 +111,9 @@ namespace geode {
         /// Check if the toggle is on.
         ///
         /// @example
-        /// ```
         /// if (toggler->isToggled()) {
         ///     log::info("Feature is enabled");
         /// }
-        /// ```
         bool isToggled() const;
 
         /// Set whether the toggle is on.
@@ -134,12 +122,10 @@ namespace geode {
         /// @param triggerCallback Whether to call the toggle callback.
         ///
         /// @example
-        /// ```
         /// toggler->setToggled(true);
         ///
         /// // Change the state without calling the callback.
         /// toggler->setToggled(false, false);
-        /// ```
         void setToggled(bool toggled, bool triggerCallback = false);
 
         /// Toggle between the on and off states.
@@ -147,21 +133,17 @@ namespace geode {
         /// @param triggerCallback Whether to call the toggle callback.
         ///
         /// @example
-        /// ```
         /// toggler->toggle();
         ///
         /// // Toggle without calling the callback.
         /// toggler->toggle(false);
-        /// ```
         void toggle(bool triggerCallback = true);
 
         /// Get the node shown when the toggle is off.
         ///
         /// @example
-        /// ```
         /// auto offNode = toggler->getOffNode();
         /// offNode->setOpacity(200);
-        /// ```
         cocos2d::CCNode* getOffNode() const;
 
         /// Change the node shown when the toggle is off.
@@ -169,19 +151,15 @@ namespace geode {
         /// @param node New off node.
         ///
         /// @example
-        /// ```
         /// auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
         /// toggler->setOffNode(offNode);
-        /// ```
         void setOffNode(cocos2d::CCNode* node);
 
         /// Get the node shown when the toggle is on.
         ///
         /// @example
-        /// ```
         /// auto onNode = toggler->getOnNode();
         /// onNode->setScale(0.8f);
-        /// ```
         cocos2d::CCNode* getOnNode() const;
 
         /// Change the node shown when the toggle is on.
@@ -189,10 +167,8 @@ namespace geode {
         /// @param node New on node.
         ///
         /// @example
-        /// ```
         /// auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
         /// toggler->setOnNode(onNode);
-        /// ```
         void setOnNode(cocos2d::CCNode* node);
 
         /// Change the callback.
@@ -200,7 +176,6 @@ namespace geode {
         /// @param callback New callback.
         ///
         /// @example
-        /// ```
         /// toggler->setToggleCallback([](Toggler* sender, bool isToggled) {
         ///     if (isToggled) {
         ///         log::info("Enabled");
@@ -208,7 +183,6 @@ namespace geode {
         ///         log::info("Disabled");
         ///     }
         /// });
-        /// ```
         void setToggleCallback(TogglerCallback callback);
 
         virtual void activate() override;

--- a/loader/include/Geode/ui/Toggler.hpp
+++ b/loader/include/Geode/ui/Toggler.hpp
@@ -5,6 +5,9 @@
 #include <Geode/ui/Button.hpp>
 
 namespace geode {
+    /// A customizable toggle button for interactive on/off controls.
+    ///
+    /// Supports custom visuals, state management, and callbacks.
     class GEODE_DLL Toggler : public Button {
     public:
         using TogglerCallback = geode::Function<void(Toggler* sender, bool isToggled)>;

--- a/loader/include/Geode/ui/Toggler.hpp
+++ b/loader/include/Geode/ui/Toggler.hpp
@@ -3,6 +3,7 @@
 #include <Geode/utils/ZStringView.hpp>
 #include <Geode/utils/function.hpp>
 #include <Geode/ui/Button.hpp>
+#include <Geode/cocos/base_nodes/CCNode.h>
 
 namespace geode {
     /// A customizable toggle button for interactive on/off controls.

--- a/loader/include/Geode/ui/Toggler.hpp
+++ b/loader/include/Geode/ui/Toggler.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+#include <Geode/utils/ZStringView.hpp>
+#include <Geode/utils/function.hpp>
+#include <Geode/ui/Button.hpp>
+
+namespace geode {
+    class GEODE_DLL Toggler : public Button {
+    public:
+        using TogglerCallback = geode::Function<void(Toggler* sender, bool isToggled)>;
+
+        /// Make a blank toggle.
+        ///
+        /// @param toggleCallback Called when the toggle changes.
+        ///
+        /// @example
+        /// ```
+        /// auto toggler = Toggler::create([](Toggler* sender, bool isToggled) {
+        ///     log::info("Toggled: {}", isToggled);
+        /// });
+        /// ```
+        static Toggler* create(TogglerCallback toggleCallback = nullptr);
+
+        /// Make a toggle with custom on/off nodes.
+        ///
+        /// @param offNode Node shown when off.
+        /// @param onNode Node shown when on.
+        /// @param toggleCallback Called when the toggle changes.
+        ///
+        /// @example
+        /// ```
+        /// auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
+        /// auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
+        ///
+        /// auto toggler = Toggler::createWithNodes(
+        ///     offNode,
+        ///     onNode,
+        ///     [](Toggler* sender, bool isToggled) {
+        ///         log::info("Toggled: {}", isToggled);
+        ///     }
+        /// );
+        /// ```
+        static Toggler* createWithNodes(
+            cocos2d::CCNode* offNode,
+            cocos2d::CCNode* onNode,
+            TogglerCallback toggleCallback = nullptr
+        );
+
+        /// Make a toggle with GD's checkbox sprites.
+        ///
+        /// @param toggleCallback Called when the toggle changes.
+        /// @param scale Checkbox scale.
+        ///
+        /// @example
+        /// ```
+        /// auto toggler = Toggler::createWithStandardSprites(
+        ///     [](Toggler* sender, bool isToggled) {
+        ///         log::info("Checkbox: {}", isToggled);
+        ///     },
+        ///     0.8f
+        /// );
+        /// ```
+        static Toggler* createWithStandardSprites(
+            TogglerCallback toggleCallback = nullptr,
+            float scale = 1.0f
+        );
+
+        /// Make a toggle using sprites from files.
+        ///
+        /// @param offFileName Sprite shown when off.
+        /// @param onFileName Sprite shown when on.
+        /// @param toggleCallback Called when the toggle changes.
+        /// @param scale Sprite scale.
+        ///
+        /// @example
+        /// ```
+        /// auto toggler = Toggler::createWithSprites(
+        ///     "off.png"_spr,
+        ///     "on.png"_spr,
+        ///     [](Toggler* sender, bool isToggled) {
+        ///         log::info("Custom toggle: {}", isToggled);
+        ///     },
+        ///     1.25f
+        /// );
+        /// ```
+        static Toggler* createWithSprites(
+            geode::ZStringView offFileName,
+            geode::ZStringView onFileName,
+            TogglerCallback toggleCallback = nullptr,
+            float scale = 1.0f
+        );
+
+        /// Make a toggle using sprites from a sprite sheet.
+        ///
+        /// @param offFrameName Frame shown when off.
+        /// @param onFrameName Frame shown when on.
+        /// @param toggleCallback Called when the toggle changes.
+        /// @param scale Sprite scale.
+        ///
+        /// @example
+        /// ```
+        /// auto toggler = Toggler::createWithSpriteFrameNames(
+        ///     "GJ_checkOff_001.png"_spr,
+        ///     "GJ_checkOn_001.png"_spr,
+        ///     [](Toggler* sender, bool isToggled) {
+        ///         log::info("Checkbox state changed: {}", isToggled);
+        ///     }
+        /// );
+        /// ```
+        static Toggler* createWithSpriteFrameNames(
+            geode::ZStringView offFrameName,
+            geode::ZStringView onFrameName,
+            TogglerCallback toggleCallback = nullptr,
+            float scale = 1.0f
+        );
+
+        /// Check if the toggle is on.
+        ///
+        /// @example
+        /// ```
+        /// if (toggler->isToggled()) {
+        ///     log::info("Feature is enabled");
+        /// }
+        /// ```
+        bool isToggled() const;
+
+        /// Set whether the toggle is on.
+        ///
+        /// @param toggled Whether the toggle should be on.
+        /// @param triggerCallback Whether to call the toggle callback.
+        ///
+        /// @example
+        /// ```
+        /// toggler->setToggled(true);
+        ///
+        /// // Change the state without calling the callback.
+        /// toggler->setToggled(false, false);
+        /// ```
+        void setToggled(bool toggled, bool triggerCallback = false);
+
+        /// Toggle between the on and off states.
+        ///
+        /// @param triggerCallback Whether to call the toggle callback.
+        ///
+        /// @example
+        /// ```
+        /// toggler->toggle();
+        ///
+        /// // Toggle without calling the callback.
+        /// toggler->toggle(false);
+        /// ```
+        void toggle(bool triggerCallback = true);
+
+        /// Get the node shown when the toggle is off.
+        ///
+        /// @example
+        /// ```
+        /// auto offNode = toggler->getOffNode();
+        /// offNode->setOpacity(200);
+        /// ```
+        cocos2d::CCNode* getOffNode() const;
+
+        /// Change the node shown when the toggle is off.
+        ///
+        /// @param node New off node.
+        ///
+        /// @example
+        /// ```
+        /// auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
+        /// toggler->setOffNode(offNode);
+        /// ```
+        void setOffNode(cocos2d::CCNode* node);
+
+        /// Get the node shown when the toggle is on.
+        ///
+        /// @example
+        /// ```
+        /// auto onNode = toggler->getOnNode();
+        /// onNode->setScale(0.8f);
+        /// ```
+        cocos2d::CCNode* getOnNode() const;
+
+        /// Change the node shown when the toggle is on.
+        ///
+        /// @param node New on node.
+        ///
+        /// @example
+        /// ```
+        /// auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
+        /// toggler->setOnNode(onNode);
+        /// ```
+        void setOnNode(cocos2d::CCNode* node);
+
+        /// Change the callback.
+        ///
+        /// @param callback New callback.
+        ///
+        /// @example
+        /// ```
+        /// toggler->setToggleCallback([](Toggler* sender, bool isToggled) {
+        ///     if (isToggled) {
+        ///         log::info("Enabled");
+        ///     } else {
+        ///         log::info("Disabled");
+        ///     }
+        /// });
+        /// ```
+        void setToggleCallback(TogglerCallback callback);
+
+        virtual void activate() override;
+
+    protected:
+        Toggler();
+        virtual ~Toggler();
+
+        bool init(TogglerCallback toggleCallback);
+
+        bool initWithNodes(
+            cocos2d::CCNode* offNode,
+            cocos2d::CCNode* onNode,
+            TogglerCallback toggleCallback
+        );
+
+        bool initWithSprites(
+            geode::ZStringView offFileName,
+            geode::ZStringView onFileName,
+            TogglerCallback toggleCallback,
+            float scale
+        );
+
+        bool initWithSpriteFrameNames(
+            geode::ZStringView offFrameName,
+            geode::ZStringView onFrameName,
+            TogglerCallback toggleCallback,
+            float scale
+        );
+
+        void updateVisuals();
+
+    private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+}

--- a/loader/include/Geode/ui/Toggler.hpp
+++ b/loader/include/Geode/ui/Toggler.hpp
@@ -13,16 +13,6 @@ namespace geode {
     public:
         using TogglerCallback = geode::Function<void(Toggler* sender, bool isToggled)>;
 
-        /// Make a blank toggle.
-        ///
-        /// @param toggleCallback Called when the toggle changes.
-        ///
-        /// @example
-        /// auto toggler = Toggler::create([](Toggler* sender, bool isToggled) {
-        ///     log::info("Toggled: {}", isToggled);
-        /// });
-        static Toggler* create(TogglerCallback toggleCallback = nullptr);
-
         /// Make a toggle with custom on/off nodes.
         ///
         /// @param offNode Node shown when off.
@@ -33,14 +23,14 @@ namespace geode {
         /// auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
         /// auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
         ///
-        /// auto toggler = Toggler::createWithNodes(
+        /// auto toggler = Toggler::create(
         ///     offNode,
         ///     onNode,
         ///     [](Toggler* sender, bool isToggled) {
         ///         log::info("Toggled: {}", isToggled);
         ///     }
         /// );
-        static Toggler* createWithNodes(
+        static Toggler* create(
             cocos2d::CCNode* offNode,
             cocos2d::CCNode* onNode,
             TogglerCallback toggleCallback = nullptr
@@ -112,7 +102,7 @@ namespace geode {
         ///
         /// @example
         /// if (toggler->isToggled()) {
-        ///     log::info("Feature is enabled");
+        ///     log::info("Toggle is enabled");
         /// }
         bool isToggled() const;
 
@@ -191,29 +181,13 @@ namespace geode {
         Toggler();
         virtual ~Toggler();
 
-        bool init(TogglerCallback toggleCallback);
-
-        bool initWithNodes(
+        bool init(
             cocos2d::CCNode* offNode,
             cocos2d::CCNode* onNode,
             TogglerCallback toggleCallback
         );
 
-        bool initWithSprites(
-            geode::ZStringView offFileName,
-            geode::ZStringView onFileName,
-            TogglerCallback toggleCallback,
-            float scale
-        );
-
-        bool initWithSpriteFrameNames(
-            geode::ZStringView offFrameName,
-            geode::ZStringView onFrameName,
-            TogglerCallback toggleCallback,
-            float scale
-        );
-
-        void updateVisuals();
+        void updateDisplay();
 
     private:
         class Impl;

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -19,7 +19,7 @@ public:
     float m_touchMultiplier = 1.f;
 
     CCPoint m_offset = {0, -15};
-    
+
     float m_selectedDuration = 0.3f;
     float m_unselectedDuration = 0.4f;
 
@@ -158,7 +158,9 @@ CCNode* Button::getDisplayNode() {
 }
 
 void Button::setDisplayNode(CCNode* node) {
-    m_impl->m_displayNode->removeFromParent();
+    if (m_impl->m_displayNode) {
+        m_impl->m_displayNode->removeFromParent();
+    }
 
     m_impl->m_displayNode = node;
 
@@ -187,7 +189,7 @@ CCActionInterval* Button::clickActionForType() {
     }
 
     return nullptr;
-}   
+}
 
 CCActionInterval* Button::releaseActionForType() {
     switch (m_impl->m_animationType) {
@@ -206,7 +208,7 @@ CCActionInterval* Button::releaseActionForType() {
             return CCEaseInOut::create(moveTo, 2.f);
         }
     }
-    
+
     return nullptr;
 }
 
@@ -297,7 +299,7 @@ void Button::selected() {
 
 void Button::unselected() {
     if (!m_impl->m_selected) return;
-    
+
     stopAction(m_impl->m_activeClickAction);
     stopAction(m_impl->m_activeReleaseAction);
 

--- a/loader/src/ui/nodes/Toggler.cpp
+++ b/loader/src/ui/nodes/Toggler.cpp
@@ -30,8 +30,14 @@ Toggler* Toggler::create(
 }
 
 Toggler* Toggler::createWithStandardSprites(
-    TogglerCallback toggleCallback,
-    float scale
+    TogglerCallback toggleCallback
+) {
+    return createWithStandardSprites(1.0f, std::move(toggleCallback));
+}
+
+Toggler* Toggler::createWithStandardSprites(
+    float scale,
+    TogglerCallback toggleCallback
 ) {
     auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
     auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
@@ -47,8 +53,16 @@ Toggler* Toggler::createWithStandardSprites(
 Toggler* Toggler::createWithSprites(
     ZStringView offFileName,
     ZStringView onFileName,
-    TogglerCallback toggleCallback,
-    float scale
+    TogglerCallback toggleCallback
+) {
+    return createWithSprites(offFileName, onFileName, 1.0f, std::move(toggleCallback));
+}
+
+Toggler* Toggler::createWithSprites(
+    ZStringView offFileName,
+    ZStringView onFileName,
+    float scale,
+    TogglerCallback toggleCallback
 ) {
     auto offNode = CCSprite::create(offFileName.c_str());
     auto onNode = CCSprite::create(onFileName.c_str());
@@ -64,8 +78,18 @@ Toggler* Toggler::createWithSprites(
 Toggler* Toggler::createWithSpriteFrameNames(
     ZStringView offFrameName,
     ZStringView onFrameName,
-    TogglerCallback toggleCallback,
-    float scale
+    TogglerCallback toggleCallback
+) {
+    return createWithSpriteFrameNames(
+        offFrameName, onFrameName, 1.0f, std::move(toggleCallback)
+    );
+}
+
+Toggler* Toggler::createWithSpriteFrameNames(
+    ZStringView offFrameName,
+    ZStringView onFrameName,
+    float scale,
+    TogglerCallback toggleCallback
 ) {
     auto offNode = CCSprite::createWithSpriteFrameName(offFrameName.c_str());
     auto onNode = CCSprite::createWithSpriteFrameName(onFrameName.c_str());

--- a/loader/src/ui/nodes/Toggler.cpp
+++ b/loader/src/ui/nodes/Toggler.cpp
@@ -1,5 +1,4 @@
 #include <Geode/ui/Toggler.hpp>
-#include <Geode/utils/cocos.hpp>
 
 using namespace geode::prelude;
 
@@ -10,30 +9,19 @@ public:
 
     CCNode* m_offNode = nullptr;
     CCNode* m_onNode = nullptr;
-    CCNode* m_containerNode = nullptr;
 };
 
 Toggler::Toggler() : m_impl(std::make_unique<Impl>()) {}
 
 Toggler::~Toggler() = default;
 
-Toggler* Toggler::create(TogglerCallback toggleCallback) {
-    auto ret = new Toggler();
-    if (ret->init(std::move(toggleCallback))) {
-        ret->autorelease();
-        return ret;
-    }
-    delete ret;
-    return nullptr;
-}
-
-Toggler* Toggler::createWithNodes(
+Toggler* Toggler::create(
     CCNode* offNode,
     CCNode* onNode,
     TogglerCallback toggleCallback
 ) {
     auto ret = new Toggler();
-    if (ret->initWithNodes(offNode, onNode, std::move(toggleCallback))) {
+    if (ret->init(offNode, onNode, std::move(toggleCallback))) {
         ret->autorelease();
         return ret;
     }
@@ -45,13 +33,15 @@ Toggler* Toggler::createWithStandardSprites(
     TogglerCallback toggleCallback,
     float scale
 ) {
-    auto offSprite = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
-    auto onSprite = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
+    auto offNode = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
+    auto onNode = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
 
-    if (offSprite) offSprite->setScale(scale);
-    if (onSprite) onSprite->setScale(scale);
+    if (!offNode || !onNode) return nullptr;
 
-    return Toggler::createWithNodes(offSprite, onSprite, std::move(toggleCallback));
+    offNode->setScale(scale);
+    onNode->setScale(scale);
+
+    return create(offNode, onNode, std::move(toggleCallback));
 }
 
 Toggler* Toggler::createWithSprites(
@@ -60,13 +50,15 @@ Toggler* Toggler::createWithSprites(
     TogglerCallback toggleCallback,
     float scale
 ) {
-    auto ret = new Toggler();
-    if (ret->initWithSprites(offFileName, onFileName, std::move(toggleCallback), scale)) {
-        ret->autorelease();
-        return ret;
-    }
-    delete ret;
-    return nullptr;
+    auto offNode = CCSprite::create(offFileName.c_str());
+    auto onNode = CCSprite::create(onFileName.c_str());
+
+    if (!offNode || !onNode) return nullptr;
+
+    offNode->setScale(scale);
+    onNode->setScale(scale);
+
+    return create(offNode, onNode, std::move(toggleCallback));
 }
 
 Toggler* Toggler::createWithSpriteFrameNames(
@@ -75,75 +67,36 @@ Toggler* Toggler::createWithSpriteFrameNames(
     TogglerCallback toggleCallback,
     float scale
 ) {
-    auto ret = new Toggler();
-    if (ret->initWithSpriteFrameNames(offFrameName, onFrameName, std::move(toggleCallback), scale)) {
-        ret->autorelease();
-        return ret;
-    }
-    delete ret;
-    return nullptr;
+    auto offNode = CCSprite::createWithSpriteFrameName(offFrameName.c_str());
+    auto onNode = CCSprite::createWithSpriteFrameName(onFrameName.c_str());
+
+    if (!offNode || !onNode) return nullptr;
+
+    offNode->setScale(scale);
+    onNode->setScale(scale);
+
+    return create(offNode, onNode, std::move(toggleCallback));
 }
 
-bool Toggler::init(TogglerCallback toggleCallback) {
-    if (!Button::init(nullptr)) return false;
-
-    m_impl->m_toggleCallback = std::move(toggleCallback);
-    m_impl->m_containerNode = CCNode::create();
-
-    setDisplayNode(m_impl->m_containerNode);
-    return true;
-}
-
-bool Toggler::initWithNodes(
+bool Toggler::init(
     CCNode* offNode,
     CCNode* onNode,
     TogglerCallback toggleCallback
 ) {
     if (!offNode || !onNode) return false;
-    if (!Button::init(nullptr)) return false;
 
-    m_impl->m_toggleCallback = std::move(toggleCallback);
-    m_impl->m_containerNode = CCNode::create();
+    if (!Button::init(nullptr)) return false;
 
     m_impl->m_offNode = offNode;
     m_impl->m_onNode = onNode;
-    m_impl->m_containerNode->addChild(m_impl->m_offNode);
-    m_impl->m_containerNode->addChild(m_impl->m_onNode);
+    m_impl->m_toggleCallback = std::move(toggleCallback);
 
-    setDisplayNode(m_impl->m_containerNode);
-    updateVisuals();
+    addChild(offNode);
+    addChild(onNode);
+
+    updateDisplay();
 
     return true;
-}
-
-bool Toggler::initWithSprites(
-    ZStringView offFileName,
-    ZStringView onFileName,
-    TogglerCallback toggleCallback,
-    float scale
-) {
-    auto offSprite = CCSprite::create(offFileName.c_str());
-    auto onSprite = CCSprite::create(onFileName.c_str());
-
-    if (offSprite) offSprite->setScale(scale);
-    if (onSprite) onSprite->setScale(scale);
-
-    return initWithNodes(offSprite, onSprite, std::move(toggleCallback));
-}
-
-bool Toggler::initWithSpriteFrameNames(
-    ZStringView offFrameName,
-    ZStringView onFrameName,
-    TogglerCallback toggleCallback,
-    float scale
-) {
-    auto offSprite = CCSprite::createWithSpriteFrameName(offFrameName.c_str());
-    auto onSprite = CCSprite::createWithSpriteFrameName(onFrameName.c_str());
-
-    if (offSprite) offSprite->setScale(scale);
-    if (onSprite) onSprite->setScale(scale);
-
-    return initWithNodes(offSprite, onSprite, std::move(toggleCallback));
 }
 
 bool Toggler::isToggled() const {
@@ -154,10 +107,10 @@ void Toggler::setToggled(bool toggled, bool triggerCallback) {
     if (m_impl->m_isToggled == toggled) return;
 
     m_impl->m_isToggled = toggled;
-    updateVisuals();
+    updateDisplay();
 
     if (triggerCallback && m_impl->m_toggleCallback) {
-        m_impl->m_toggleCallback(this, m_impl->m_isToggled);
+        m_impl->m_toggleCallback(this, toggled);
     }
 }
 
@@ -170,16 +123,14 @@ CCNode* Toggler::getOffNode() const {
 }
 
 void Toggler::setOffNode(CCNode* node) {
-    if (m_impl->m_offNode) {
-        m_impl->m_offNode->removeFromParent();
-    }
+    if (!node || node == m_impl->m_offNode) return;
+
+    m_impl->m_offNode->removeFromParent();
 
     m_impl->m_offNode = node;
-    if (m_impl->m_offNode) {
-        m_impl->m_containerNode->addChild(m_impl->m_offNode);
-    }
+    addChild(node);
 
-    updateVisuals();
+    updateDisplay();
 }
 
 CCNode* Toggler::getOnNode() const {
@@ -187,16 +138,14 @@ CCNode* Toggler::getOnNode() const {
 }
 
 void Toggler::setOnNode(CCNode* node) {
-    if (m_impl->m_onNode) {
-        m_impl->m_onNode->removeFromParent();
-    }
+    if (!node || node == m_impl->m_onNode) return;
+
+    m_impl->m_onNode->removeFromParent();
 
     m_impl->m_onNode = node;
-    if (m_impl->m_onNode) {
-        m_impl->m_containerNode->addChild(m_impl->m_onNode);
-    }
+    addChild(node);
 
-    updateVisuals();
+    updateDisplay();
 }
 
 void Toggler::setToggleCallback(TogglerCallback callback) {
@@ -207,22 +156,22 @@ void Toggler::activate() {
     if (!isEnabled()) return;
 
     Button::activate();
-
     toggle(true);
 }
 
-void Toggler::updateVisuals() {
-    if (!m_impl->m_offNode || !m_impl->m_onNode) return;
+void Toggler::updateDisplay() {
+    auto activeNode = m_impl->m_isToggled
+        ? m_impl->m_onNode
+        : m_impl->m_offNode;
+
+    auto size = activeNode->getScaledContentSize();
+    auto center = size * 0.5f;
 
     m_impl->m_offNode->setVisible(!m_impl->m_isToggled);
     m_impl->m_onNode->setVisible(m_impl->m_isToggled);
 
-    auto activeNode = m_impl->m_isToggled ? m_impl->m_onNode : m_impl->m_offNode;
-    auto size = activeNode->getScaledContentSize();
-    auto center = size * 0.5f;
-
-    m_impl->m_containerNode->setContentSize(size);
     m_impl->m_offNode->setPosition(center);
     m_impl->m_onNode->setPosition(center);
+
     setContentSize(size);
 }

--- a/loader/src/ui/nodes/Toggler.cpp
+++ b/loader/src/ui/nodes/Toggler.cpp
@@ -1,0 +1,248 @@
+#include <Geode/ui/Toggler.hpp>
+#include <Geode/utils/cocos.hpp>
+
+using namespace geode::prelude;
+
+class Toggler::Impl final {
+public:
+    TogglerCallback m_toggleCallback = nullptr;
+    bool m_isToggled = false;
+
+    CCNode* m_offNode = nullptr;
+    CCNode* m_onNode = nullptr;
+    CCNode* m_containerNode = nullptr;
+};
+
+Toggler::Toggler() : m_impl(std::make_unique<Impl>()) {}
+
+Toggler::~Toggler() = default;
+
+Toggler* Toggler::create(TogglerCallback toggleCallback) {
+    auto ret = new Toggler();
+    if (ret->init(std::move(toggleCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Toggler* Toggler::createWithNodes(
+    CCNode* offNode,
+    CCNode* onNode,
+    TogglerCallback toggleCallback
+) {
+    auto ret = new Toggler();
+    if (ret->initWithNodes(offNode, onNode, std::move(toggleCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Toggler* Toggler::createWithStandardSprites(
+    TogglerCallback toggleCallback,
+    float scale
+) {
+    auto offSprite = CCSprite::createWithSpriteFrameName("GJ_checkOff_001.png");
+    auto onSprite = CCSprite::createWithSpriteFrameName("GJ_checkOn_001.png");
+
+    if (offSprite) offSprite->setScale(scale);
+    if (onSprite) onSprite->setScale(scale);
+
+    return Toggler::createWithNodes(offSprite, onSprite, std::move(toggleCallback));
+}
+
+Toggler* Toggler::createWithSprites(
+    ZStringView offFileName,
+    ZStringView onFileName,
+    TogglerCallback toggleCallback,
+    float scale
+) {
+    auto ret = new Toggler();
+    if (ret->initWithSprites(offFileName, onFileName, std::move(toggleCallback), scale)) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Toggler* Toggler::createWithSpriteFrameNames(
+    ZStringView offFrameName,
+    ZStringView onFrameName,
+    TogglerCallback toggleCallback,
+    float scale
+) {
+    auto ret = new Toggler();
+    if (ret->initWithSpriteFrameNames(offFrameName, onFrameName, std::move(toggleCallback), scale)) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+bool Toggler::init(TogglerCallback toggleCallback) {
+    if (!Button::init(nullptr)) return false;
+
+    m_impl->m_toggleCallback = std::move(toggleCallback);
+    m_impl->m_containerNode = CCNode::create();
+
+    setDisplayNode(m_impl->m_containerNode);
+    return true;
+}
+
+bool Toggler::initWithNodes(
+    CCNode* offNode,
+    CCNode* onNode,
+    TogglerCallback toggleCallback
+) {
+    if (!offNode || !onNode) return false;
+    if (!Button::init(nullptr)) return false;
+
+    m_impl->m_toggleCallback = std::move(toggleCallback);
+    m_impl->m_containerNode = CCNode::create();
+
+    m_impl->m_offNode = offNode;
+    m_impl->m_onNode = onNode;
+    m_impl->m_containerNode->addChild(m_impl->m_offNode);
+    m_impl->m_containerNode->addChild(m_impl->m_onNode);
+
+    setDisplayNode(m_impl->m_containerNode);
+    updateVisuals();
+
+    return true;
+}
+
+bool Toggler::initWithSprites(
+    ZStringView offFileName,
+    ZStringView onFileName,
+    TogglerCallback toggleCallback,
+    float scale
+) {
+    auto offSprite = CCSprite::create(offFileName.c_str());
+    auto onSprite = CCSprite::create(onFileName.c_str());
+
+    if (offSprite) offSprite->setScale(scale);
+    if (onSprite) onSprite->setScale(scale);
+
+    return initWithNodes(offSprite, onSprite, std::move(toggleCallback));
+}
+
+bool Toggler::initWithSpriteFrameNames(
+    ZStringView offFrameName,
+    ZStringView onFrameName,
+    TogglerCallback toggleCallback,
+    float scale
+) {
+    auto offSprite = CCSprite::createWithSpriteFrameName(offFrameName.c_str());
+    auto onSprite = CCSprite::createWithSpriteFrameName(onFrameName.c_str());
+
+    if (offSprite) offSprite->setScale(scale);
+    if (onSprite) onSprite->setScale(scale);
+
+    return initWithNodes(offSprite, onSprite, std::move(toggleCallback));
+}
+
+bool Toggler::isToggled() const {
+    return m_impl->m_isToggled;
+}
+
+void Toggler::setToggled(bool toggled, bool triggerCallback) {
+    if (m_impl->m_isToggled == toggled) return;
+
+    m_impl->m_isToggled = toggled;
+    updateVisuals();
+
+    if (triggerCallback && m_impl->m_toggleCallback) {
+        m_impl->m_toggleCallback(this, m_impl->m_isToggled);
+    }
+}
+
+void Toggler::toggle(bool triggerCallback) {
+    setToggled(!m_impl->m_isToggled, triggerCallback);
+}
+
+CCNode* Toggler::getOffNode() const {
+    return m_impl->m_offNode;
+}
+
+void Toggler::setOffNode(CCNode* node) {
+    if (m_impl->m_offNode) {
+        m_impl->m_offNode->removeFromParent();
+    }
+
+    m_impl->m_offNode = node;
+    if (m_impl->m_offNode) {
+        m_impl->m_containerNode->addChild(m_impl->m_offNode);
+    }
+
+    updateVisuals();
+}
+
+CCNode* Toggler::getOnNode() const {
+    return m_impl->m_onNode;
+}
+
+void Toggler::setOnNode(CCNode* node) {
+    if (m_impl->m_onNode) {
+        m_impl->m_onNode->removeFromParent();
+    }
+
+    m_impl->m_onNode = node;
+    if (m_impl->m_onNode) {
+        m_impl->m_containerNode->addChild(m_impl->m_onNode);
+    }
+
+    updateVisuals();
+}
+
+
+void Toggler::setToggleCallback(TogglerCallback callback) {
+    m_impl->m_toggleCallback = std::move(callback);
+}
+
+void Toggler::activate() {
+    if (!isEnabled()) return;
+
+    Button::activate();
+
+    toggle(true);
+}
+
+void Toggler::updateVisuals() {
+    if (!m_impl->m_containerNode) return;
+
+    auto offNode = m_impl->m_offNode;
+    auto onNode = m_impl->m_onNode;
+
+    if (offNode) {
+        offNode->setVisible(!m_impl->m_isToggled);
+    }
+
+    if (onNode) {
+        onNode->setVisible(m_impl->m_isToggled);
+    }
+
+    auto activeNode = m_impl->m_isToggled ? onNode : offNode;
+    auto size = activeNode ? activeNode->getScaledContentSize() : CCSize{};
+
+    m_impl->m_containerNode->setContentSize(size);
+    m_impl->m_containerNode->setAnchorPoint({0.5f, 0.5f});
+
+    auto center = size / 2.f;
+
+    if (offNode) {
+        offNode->setAnchorPoint({0.5f, 0.5f});
+        offNode->setPosition(center);
+    }
+
+    if (onNode) {
+        onNode->setAnchorPoint({0.5f, 0.5f});
+        onNode->setPosition(center);
+    }
+
+    setContentSize(size);
+}

--- a/loader/src/ui/nodes/Toggler.cpp
+++ b/loader/src/ui/nodes/Toggler.cpp
@@ -213,36 +213,21 @@ void Toggler::activate() {
 }
 
 void Toggler::updateVisuals() {
-    if (!m_impl->m_containerNode) return;
-
-    auto offNode = m_impl->m_offNode;
-    auto onNode = m_impl->m_onNode;
-
-    if (offNode) {
-        offNode->setVisible(!m_impl->m_isToggled);
+    if (m_impl->m_offNode) {
+        m_impl->m_offNode->setVisible(!m_impl->m_isToggled);
+    }
+    if (m_impl->m_onNode) {
+        m_impl->m_onNode->setVisible(m_impl->m_isToggled);
     }
 
-    if (onNode) {
-        onNode->setVisible(m_impl->m_isToggled);
-    }
+    auto activeNode = m_impl->m_isToggled ? m_impl->m_onNode : m_impl->m_offNode;
+    if (!activeNode) return;
 
-    auto activeNode = m_impl->m_isToggled ? onNode : offNode;
-    auto size = activeNode ? activeNode->getScaledContentSize() : CCSize{};
-
+    auto size = activeNode->getScaledContentSize();
     m_impl->m_containerNode->setContentSize(size);
-    m_impl->m_containerNode->setAnchorPoint({0.5f, 0.5f});
 
-    auto center = size / 2.f;
-
-    if (offNode) {
-        offNode->setAnchorPoint({0.5f, 0.5f});
-        offNode->setPosition(center);
-    }
-
-    if (onNode) {
-        onNode->setAnchorPoint({0.5f, 0.5f});
-        onNode->setPosition(center);
-    }
+    m_impl->m_offNode->setPosition(size * 0.5f);
+    m_impl->m_onNode->setPosition(size * 0.5f);
 
     setContentSize(size);
 }

--- a/loader/src/ui/nodes/Toggler.cpp
+++ b/loader/src/ui/nodes/Toggler.cpp
@@ -212,25 +212,17 @@ void Toggler::activate() {
 }
 
 void Toggler::updateVisuals() {
-    if (m_impl->m_offNode) {
-        m_impl->m_offNode->setVisible(!m_impl->m_isToggled);
-    }
-    if (m_impl->m_onNode) {
-        m_impl->m_onNode->setVisible(m_impl->m_isToggled);
-    }
+    if (!m_impl->m_offNode || !m_impl->m_onNode) return;
+
+    m_impl->m_offNode->setVisible(!m_impl->m_isToggled);
+    m_impl->m_onNode->setVisible(m_impl->m_isToggled);
 
     auto activeNode = m_impl->m_isToggled ? m_impl->m_onNode : m_impl->m_offNode;
-    if (!activeNode) return;
-
     auto size = activeNode->getScaledContentSize();
+    auto center = size * 0.5f;
+
     m_impl->m_containerNode->setContentSize(size);
-
-    if (m_impl->m_offNode) {
-        m_impl->m_offNode->setPosition(size * 0.5f);
-    }
-    if (m_impl->m_onNode) {
-        m_impl->m_onNode->setPosition(size * 0.5f);
-    }
-
+    m_impl->m_offNode->setPosition(center);
+    m_impl->m_onNode->setPosition(center);
     setContentSize(size);
 }

--- a/loader/src/ui/nodes/Toggler.cpp
+++ b/loader/src/ui/nodes/Toggler.cpp
@@ -199,7 +199,6 @@ void Toggler::setOnNode(CCNode* node) {
     updateVisuals();
 }
 
-
 void Toggler::setToggleCallback(TogglerCallback callback) {
     m_impl->m_toggleCallback = std::move(callback);
 }
@@ -226,8 +225,12 @@ void Toggler::updateVisuals() {
     auto size = activeNode->getScaledContentSize();
     m_impl->m_containerNode->setContentSize(size);
 
-    m_impl->m_offNode->setPosition(size * 0.5f);
-    m_impl->m_onNode->setPosition(size * 0.5f);
+    if (m_impl->m_offNode) {
+        m_impl->m_offNode->setPosition(size * 0.5f);
+    }
+    if (m_impl->m_onNode) {
+        m_impl->m_onNode->setPosition(size * 0.5f);
+    }
 
     setContentSize(size);
 }


### PR DESCRIPTION
A nice toggler button that wraps around geode::Button

Benefits over CCMenuItemToggler:
- Same benefits as geode::Button
- Does not have the inverted logic bug like CCMenuItemToggler