### PR TITLE
Add createWithButtonSprite function to geode::Button

### DIFF
--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -2,7 +2,6 @@
 
 #include <Geode/utils/ZStringView.hpp>
 #include <cocos2d.h>
-#include <Geode/binding/ButtonSprite.hpp>
 
 namespace geode {
     class GEODE_DLL Button : public cocos2d::CCNodeRGBA, public cocos2d::CCTouchDelegate {

--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -60,6 +60,35 @@ namespace geode {
         /**
          * Create a Button with a ButtonSprite
          * @param text The text shown in the button
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithButtonSprite(geode::ZStringView text, ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Create a Button with a ButtonSprite
+         * @param text The text shown in the button
+         * @param scale The scale of the ButtonSprite
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithButtonSprite(geode::ZStringView text, float scale, ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Create a Button with a ButtonSprite
+         * @param text The text shown in the button
+         * @param font The font of the text
+         * @param bg The background of the button
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithButtonSprite(
+            geode::ZStringView text,
+            geode::ZStringView font,
+            geode::ZStringView bg,
+            ButtonCallback activateCallback = nullptr
+        );
+
+        /**
+         * Create a Button with a ButtonSprite
+         * @param text The text shown in the button
          * @param font The font of the text
          * @param bg The background of the button
          * @param scale The scale of the ButtonSprite
@@ -67,9 +96,29 @@ namespace geode {
          */
         static Button* createWithButtonSprite(
             geode::ZStringView text,
-            geode::ZStringView font = "goldFont.fnt",
-            geode::ZStringView bg = "GJ_button_01.png",
-            float scale = 1.f,
+            geode::ZStringView font,
+            geode::ZStringView bg,
+            float scale,
+            ButtonCallback activateCallback = nullptr
+        );
+
+        /**
+         * Create a Button with a ButtonSprite
+         * @param text The text shown in the button
+         * @param font The font of the text
+         * @param bg The background of the button
+         * @param width The width of the button
+         * @param absolute idk
+         * @param scale The scale of the ButtonSprite
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithButtonSprite(
+            geode::ZStringView text,
+            geode::ZStringView font,
+            geode::ZStringView bg,
+            int width,
+            bool absolute,
+            float scale,
             ButtonCallback activateCallback = nullptr
         );
 
@@ -80,17 +129,18 @@ namespace geode {
          * @param bg The background of the button
          * @param width The width of the button
          * @param height The height of the button
+         * @param absolute idk
          * @param scale The scale of the ButtonSprite
          * @param activateCallback The callback for when the button is activated
          */
         static Button* createWithButtonSprite(
             geode::ZStringView text,
-            geode::ZStringView font = "goldFont.fnt",
-            geode::ZStringView bg = "GJ_button_01.png",
-            int width = 0,
-            float height = .0f,
-            bool absolute = false,
-            float scale = 1.f,
+            geode::ZStringView font,
+            geode::ZStringView bg,
+            int width,
+            float height,
+            bool absolute,
+            float scale,
             ButtonCallback activateCallback = nullptr
         );
 

--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -3,7 +3,6 @@
 #include <Geode/utils/ZStringView.hpp>
 #include <cocos2d.h>
 #include <Geode/binding/ButtonSprite.hpp>
-#include <ui/mods/GeodeStyle.hpp>
 
 namespace geode {
     class GEODE_DLL Button : public cocos2d::CCNodeRGBA, public cocos2d::CCTouchDelegate {

--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -27,7 +27,7 @@ namespace geode {
         static Button* create(ButtonCallback activateCallback = nullptr);
 
         /**
-         * Create a Button with a nodes on it.
+         * Create a Button with a node on it.
          * The node will be automatically positioned in the center.
          * @param node The node that will show on the button.
          * @param activateCallback The callback for when the button is activated

--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -2,6 +2,8 @@
 
 #include <Geode/utils/ZStringView.hpp>
 #include <cocos2d.h>
+#include <Geode/binding/ButtonSprite.hpp>
+#include <ui/mods/GeodeStyle.hpp>
 
 namespace geode {
     class GEODE_DLL Button : public cocos2d::CCNodeRGBA, public cocos2d::CCTouchDelegate {
@@ -57,6 +59,43 @@ namespace geode {
         static Button* createWithLabel(geode::ZStringView text, geode::ZStringView font, ButtonCallback activateCallback = nullptr);
 
         /**
+         * Create a Button with a ButtonSprite
+         * @param text The text shown in the button
+         * @param font The font of the text
+         * @param bg The background of the button
+         * @param scale The scale of the ButtonSprite
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithButtonSprite(
+            geode::ZStringView text,
+            geode::ZStringView font = "goldFont.fnt",
+            geode::ZStringView bg = "GJ_button_01.png",
+            float scale = 1.f,
+            ButtonCallback activateCallback = nullptr
+        );
+
+        /**
+         * Create a Button with a ButtonSprite
+         * @param text The text shown in the button
+         * @param font The font of the text
+         * @param bg The background of the button
+         * @param width The width of the button
+         * @param height The height of the button
+         * @param scale The scale of the ButtonSprite
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithButtonSprite(
+            geode::ZStringView text,
+            geode::ZStringView font = "goldFont.fnt",
+            geode::ZStringView bg = "GJ_button_01.png",
+            int width = 0,
+            float height = .0f,
+            bool absolute = false,
+            float scale = 1.f,
+            ButtonCallback activateCallback = nullptr
+        );
+
+        /**
          * Get the Display Node, which was created or passed in on button creation
          * Will be nullptr if you use the empty create method
          */
@@ -108,7 +147,7 @@ namespace geode {
         int getTouchPriority();
 
         /**
-         * Set the touch multiplier, which increases the distance from the 
+         * Set the touch multiplier, which increases the distance from the
          * center that the button can be pressed (default is 1)
          */
         void setTouchMultiplier(float multipler);
@@ -145,7 +184,7 @@ namespace geode {
          */
         virtual void setEnabled(bool enabled);
         virtual bool isEnabled();
-        
+
         /**
          * Get the selected state of the button
          */
@@ -208,7 +247,7 @@ namespace geode {
          * Unregister a button (must be called in onExit)
          */
         void unregisterButton(Button* button);
-        
+
         /**
          * Pass moves from ccTouchMoved to all buttons sharing a parent
          */

--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -107,7 +107,7 @@ namespace geode {
          * @param font The font of the text
          * @param bg The background of the button
          * @param width The width of the button
-         * @param absolute idk
+         * @param absolute Whether to use absolute sizing for the button sprite
          * @param scale The scale of the ButtonSprite
          * @param activateCallback The callback for when the button is activated
          */
@@ -128,7 +128,7 @@ namespace geode {
          * @param bg The background of the button
          * @param width The width of the button
          * @param height The height of the button
-         * @param absolute idk
+         * @param absolute Whether to use absolute sizing for the button sprite
          * @param scale The scale of the ButtonSprite
          * @param activateCallback The callback for when the button is activated
          */

--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -66,7 +66,7 @@ namespace geode {
         /**
          * Create a Button with a ButtonSprite
          * @param text The text shown in the button
-         * @param scale The scale of the ButtonSprite
+         * @param scale The scale of the text
          * @param activateCallback The callback for when the button is activated
          */
         static Button* createWithButtonSprite(geode::ZStringView text, float scale, ButtonCallback activateCallback = nullptr);
@@ -75,7 +75,7 @@ namespace geode {
          * Create a Button with a ButtonSprite
          * @param text The text shown in the button
          * @param font The font of the text
-         * @param bg The background of the button
+         * @param bg The background of the button (not in a spritesheet)
          * @param activateCallback The callback for when the button is activated
          */
         static Button* createWithButtonSprite(
@@ -89,8 +89,8 @@ namespace geode {
          * Create a Button with a ButtonSprite
          * @param text The text shown in the button
          * @param font The font of the text
-         * @param bg The background of the button
-         * @param scale The scale of the ButtonSprite
+         * @param bg The background of the button (not in a spritesheet)
+         * @param scale The scale of the text
          * @param activateCallback The callback for when the button is activated
          */
         static Button* createWithButtonSprite(
@@ -105,10 +105,10 @@ namespace geode {
          * Create a Button with a ButtonSprite
          * @param text The text shown in the button
          * @param font The font of the text
-         * @param bg The background of the button
-         * @param width The width of the button
-         * @param absolute Whether to use absolute sizing for the button sprite
-         * @param scale The scale of the ButtonSprite
+         * @param bg The background of the button (not in a spritesheet)
+         * @param width The width of the button (`absolute` must be true)
+         * @param absolute Whether to use absolute width or not
+         * @param scale The scale of the text
          * @param activateCallback The callback for when the button is activated
          */
         static Button* createWithButtonSprite(
@@ -125,11 +125,11 @@ namespace geode {
          * Create a Button with a ButtonSprite
          * @param text The text shown in the button
          * @param font The font of the text
-         * @param bg The background of the button
-         * @param width The width of the button
-         * @param height The height of the button
-         * @param absolute Whether to use absolute sizing for the button sprite
-         * @param scale The scale of the ButtonSprite
+         * @param bg The background of the button (not in a spritesheet)
+         * @param width The width of the button (`absolute` must be true)
+         * @param height The height of the button (0 automatically sets the height)
+         * @param absolute Whether to use absolute width or not
+         * @param scale The scale of the text
          * @param activateCallback The callback for when the button is activated
          */
         static Button* createWithButtonSprite(

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -1,7 +1,6 @@
 #include <Geode/ui/Button.hpp>
 #include <Geode/utils/cocos.hpp>
 #include <Geode/binding/ButtonSprite.hpp>
-#include <Geode/ui/GeodeUI.hpp>
 
 using namespace geode::prelude;
 

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -110,7 +110,7 @@ Button* Button::createWithButtonSprite(
     float scale,
     ButtonCallback activateCallback
 ) {
-    return Button::createWithButtonSprite(text.c_str(), font.c_str(), bg.c_str(), 0, .0f, false, scale, std::move(activateCallback));
+    return Button::createWithButtonSprite(text, font, bg, 0, .0f, false, scale, std::move(activateCallback));
 }
 
 Button* Button::createWithButtonSprite(

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -91,6 +91,18 @@ Button* Button::createWithLabel(ZStringView text, ZStringView font, ButtonCallba
     return nullptr;
 }
 
+Button* Button::createWithButtonSprite(ZStringView text, ButtonCallback activateCallback) {
+    return Button::createWithButtonSprite(text, "goldFont.fnt", "GJ_button_01.png", 0, 0.f, false, 1.f, std::move(activateCallback));
+}
+
+Button* Button::createWithButtonSprite(ZStringView text, float scale, ButtonCallback activateCallback) {
+    return Button::createWithButtonSprite(text, "goldFont.fnt", "GJ_button_01.png", 0, 0.f, false, scale, std::move(activateCallback));
+}
+
+Button* Button::createWithButtonSprite(ZStringView text, ZStringView font, ZStringView bg, ButtonCallback activateCallback) {
+    return Button::createWithButtonSprite(text, font, bg, std::move(activateCallback));
+}
+
 Button* Button::createWithButtonSprite(
     ZStringView text,
     ZStringView font,
@@ -99,6 +111,18 @@ Button* Button::createWithButtonSprite(
     ButtonCallback activateCallback
 ) {
     return Button::createWithButtonSprite(text.c_str(), font.c_str(), bg.c_str(), 0, .0f, false, scale, std::move(activateCallback));
+}
+
+Button* Button::createWithButtonSprite(
+    ZStringView text,
+    ZStringView font,
+    ZStringView bg,
+    int width,
+    bool absolute,
+    float scale,
+    ButtonCallback activateCallback
+) {
+    return Button::createWithButtonSprite(text, font, bg, width, 0, absolute, scale, std::move(activateCallback));
 }
 
 Button* Button::createWithButtonSprite(

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -1,5 +1,7 @@
 #include <Geode/ui/Button.hpp>
 #include <Geode/utils/cocos.hpp>
+#include <Geode/binding/ButtonSprite.hpp>
+#include <Geode/ui/GeodeUI.hpp>
 
 using namespace geode::prelude;
 
@@ -19,7 +21,7 @@ public:
     float m_touchMultiplier = 1.f;
 
     CCPoint m_offset = {0, -15};
-    
+
     float m_selectedDuration = 0.3f;
     float m_unselectedDuration = 0.4f;
 
@@ -83,6 +85,45 @@ Button* Button::createWithSpriteFrameName(ZStringView frameName, ButtonCallback 
 Button* Button::createWithLabel(ZStringView text, ZStringView font, ButtonCallback activateCallback) {
     auto ret = new Button();
     if (ret->initWithLabel(std::move(text), std::move(font), std::move(activateCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Button* Button::createWithButtonSprite(
+    ZStringView text,
+    ZStringView font,
+    ZStringView bg,
+    float scale,
+    ButtonCallback activateCallback
+) {
+    return Button::createWithButtonSprite(text.c_str(), font.c_str(), bg.c_str(), 0, .0f, false, scale, std::move(activateCallback));
+}
+
+Button* Button::createWithButtonSprite(
+    ZStringView text,
+    ZStringView font,
+    ZStringView bg,
+    int width,
+    float height,
+    bool absolute,
+    float scale,
+    ButtonCallback activateCallback
+) {
+    auto ret = new Button();
+    auto spr = ButtonSprite::create(
+        text.c_str(),
+        width,
+        absolute,
+        font.c_str(),
+        bg.c_str(),
+        height,
+        scale
+    );
+    if (!spr) return nullptr;
+    if (ret->initWithNode(spr, std::move(activateCallback))) {
         ret->autorelease();
         return ret;
     }
@@ -187,7 +228,7 @@ CCActionInterval* Button::clickActionForType() {
     }
 
     return nullptr;
-}   
+}
 
 CCActionInterval* Button::releaseActionForType() {
     switch (m_impl->m_animationType) {
@@ -206,7 +247,7 @@ CCActionInterval* Button::releaseActionForType() {
             return CCEaseInOut::create(moveTo, 2.f);
         }
     }
-    
+
     return nullptr;
 }
 
@@ -297,7 +338,7 @@ void Button::selected() {
 
 void Button::unselected() {
     if (!m_impl->m_selected) return;
-    
+
     stopAction(m_impl->m_activeClickAction);
     stopAction(m_impl->m_activeReleaseAction);
 


### PR DESCRIPTION
Instead of having to manually make a `ButtonSprite` and passing that to `Button::createWithNode`, why not just have a helper that can make that?

Now you can easily make one with `createWithButtonSprite`:
```cpp
auto btn = Button::createWithButtonSprite("My Own Button!", [](auto) {
    log::info("My own button was pressed!");
});
```

And if you need to change anything on it (let's say, the font/background sprite) you can do that too:
```cpp
auto btn = Button::createWithButtonSprite("My Own Button!", "bigFont.fnt", "GJ_button_02.png", [](auto) {
    log::info("My own button was pressed!");
});
```

This should work perfectly fine for 99% of cases, but I'm open to feedback on what I can change