### PR TITLE
make total update progress bar remember the size it started with so that it doesnt jump back every time a mod finishes updating

### DIFF
--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -231,15 +231,24 @@ void ModsStatusNode::updateState() {
 
         case DownloadState::SomeDownloading: {
             size_t totalProgress = 0;
-            size_t totalDownloading = 0;
+            // size_t totalDownloading = 0;
+
             for (auto& download : downloads) {
                 auto status = download.getStatus();
+                /*
                 if (auto loading = std::get_if<server::DownloadStatusDownloading>(&status)) {
                     totalProgress += loading->percentage;
                     totalDownloading += 1;
                 }
+                */
+                if (std::holds_alternative<server::DownloadStatusDone>(status)) {
+                    totalProgress += 100;
+                } else if (auto downloading = std::get_if<server::DownloadStatusDownloading>(&status)) {
+                    totalProgress += downloading->percentage;
+                }
             }
-            auto percentage = totalProgress / static_cast<float>(totalDownloading);
+            auto totalDownloads = downloads.size();
+            auto percentage = totalProgress / static_cast<float>(totalDownloads);
 
             m_statusPercentage->setString(fmt::format("{}%", static_cast<size_t>(percentage)).c_str());
             m_statusPercentage->setVisible(true);


### PR DESCRIPTION
from https://discord.com/channels/911701438269386882/1186973675661041725/1542080664671748186

please let me know what to change (if needed) (this is my first geode pr after all)