### PR TITLE
[v6] swap MDTextArea to use geode::Label

### DIFF
--- a/loader/include/Geode/ui/TextRenderer.hpp
+++ b/loader/include/Geode/ui/TextRenderer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cocos2d.h>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/function.hpp>
 
 namespace geode {
@@ -115,6 +116,8 @@ namespace geode {
                     if constexpr (std::is_same_v<cocos2d::CCLabelBMFont, T>) {
                         m_lineHeight = label->getConfiguration()->m_nCommonHeight /
                             cocos2d::CC_CONTENT_SCALE_FACTOR();
+                    } else if constexpr (std::is_same_v<geode::Label, T>) {
+                        m_lineHeight = label->getFont()->getCommonHeightScaled();
                     }
                 }
             }

--- a/loader/src/ui/nodes/MDTextArea.cpp
+++ b/loader/src/ui/nodes/MDTextArea.cpp
@@ -6,8 +6,9 @@
 #include <Geode/binding/LevelBrowserLayer.hpp>
 #include <Geode/loader/Mod.hpp>
 #include <Geode/loader/Loader.hpp>
-#include <Geode/ui/MDTextArea.hpp>
 #include <Geode/ui/BreakLine.hpp>
+#include <Geode/ui/Label.hpp>
+#include <Geode/ui/MDTextArea.hpp>
 #include <Geode/ui/NineSlice.hpp>
 #include <Geode/utils/casts.hpp>
 #include <Geode/utils/cocos.hpp>
@@ -47,21 +48,21 @@ MDTextArea::MDTextArea() : m_impl(std::make_unique<Impl>()) {}
 auto makeMdFont() -> TextRenderer::Font {
     return [](int style) -> TextRenderer::Label {
         if ((style & TextStyleBold) && (style & TextStyleItalic)) {
-            return CCLabelBMFont::create("", "mdFontBI.fnt"_spr);
+            return Label::create("", "mdFontBI.fnt"_spr);
         }
         if ((style & TextStyleBold)) {
-            return CCLabelBMFont::create("", "mdFontB.fnt"_spr);
+            return Label::create("", "mdFontB.fnt"_spr);
         }
         if ((style & TextStyleItalic)) {
-            return CCLabelBMFont::create("", "mdFontI.fnt"_spr);
+            return Label::create("", "mdFontI.fnt"_spr);
         }
-        return CCLabelBMFont::create("", "mdFont.fnt"_spr);
+        return Label::create("", "mdFont.fnt"_spr);
     };
 }
 
 auto makeMdMonoFont() -> TextRenderer::Font {
     return [](int style) -> TextRenderer::Label {
-        return CCLabelBMFont::create("", "mdFontMono.fnt"_spr);
+        return Label::create("", "mdFontMono.fnt"_spr);
     };
 }
 

--- a/loader/src/ui/nodes/TextRenderer.cpp
+++ b/loader/src/ui/nodes/TextRenderer.cpp
@@ -1,3 +1,4 @@
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/TextRenderer.hpp>
 #include <Geode/utils/casts.hpp>
 #include <Geode/utils/cocos.hpp>
@@ -540,7 +541,7 @@ float TextRenderer::adjustLineAlignment() {
 
 void TextRenderer::pushBMFont(char const* bmFont) {
     m_fontStack.push_back([bmFont](int) -> Label {
-        return CCLabelBMFont::create("", bmFont);
+        return geode::Label::create("", bmFont);
     });
 }
 
@@ -555,7 +556,7 @@ void TextRenderer::popFont() {
 TextRenderer::FontRef TextRenderer::getCurrentFont() const {
     if (!m_fontStack.size()) {
         return [](int) -> Label {
-            return CCLabelBMFont::create("", "bigFont.fnt");
+            return geode::Label::create("", "bigFont.fnt");
         };
     }
     return m_fontStack.back();


### PR DESCRIPTION
This should be everything that needs to be swapped for it to work 1:1 with v5, I spot checked a few mod changelogs and everything looks fine.