### PR TITLE
[v6] migrate most CCLabelBMFont usage to geode::Label

### DIFF
--- a/loader/include/Geode/loader/SettingV3.hpp
+++ b/loader/include/Geode/loader/SettingV3.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <concepts>
 #include <cocos2d.h>
+#include <Geode/ui/Label.hpp>
 #include "../utils/cocos.hpp"
 #include "../utils/file.hpp"
 // this unfortunately has to be included because of C++ templates
@@ -654,9 +655,9 @@ namespace geode {
         // Can / should be used to do alternating BG
         void setDefaultBGColor(cocos2d::ccColor4B color);
 
-        cocos2d::CCLabelBMFont* getNameLabel() const;
+        geode::Label* getNameLabel() const;
         CCMenuItemSpriteExtra* getDescriptionButton() const;
-        cocos2d::CCLabelBMFont* getStatusLabel() const;
+        geode::Label* getStatusLabel() const;
         cocos2d::CCMenu* getNameMenu() const;
         cocos2d::CCMenu* getButtonMenu() const;
         cocos2d::CCLayerColor* getBG() const;
@@ -700,7 +701,7 @@ namespace geode {
             auto validate = this->getSetting()->isValid(m_impl->currentValue);
             if (!validate) {
                 this->getStatusLabel()->setVisible(true);
-                this->getStatusLabel()->setString(validate.unwrapErr().c_str());
+                this->getStatusLabel()->setText(validate.unwrapErr());
                 this->getStatusLabel()->setColor(cocos2d::ccc3(235, 35, 52));
             }
         }

--- a/loader/include/Geode/ui/IconButtonSprite.hpp
+++ b/loader/include/Geode/ui/IconButtonSprite.hpp
@@ -2,6 +2,7 @@
 
 #include <cocos2d.h>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 
 namespace geode {
     class GEODE_DLL IconButtonSprite : public cocos2d::CCSprite, public cocos2d::CCLabelProtocol {
@@ -39,7 +40,7 @@ namespace geode {
         void setColor(cocos2d::ccColor3B const& color) override;
         void setOpacity(GLubyte opacity) override;
         NineSlice* getBg();
-        cocos2d::CCLabelBMFont* getLabel();
+        Label* getLabel();
         cocos2d::CCNode* getIcon();
     };
 }

--- a/loader/include/Geode/ui/Notification.hpp
+++ b/loader/include/Geode/ui/Notification.hpp
@@ -4,6 +4,7 @@
 #include <cocos-ext.h>
 #include <Geode/binding/TextAlertPopup.hpp>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 
 namespace geode {
     constexpr auto NOTIFICATION_DEFAULT_TIME = 1.8f;
@@ -34,7 +35,7 @@ namespace geode {
         void waitThenHide();
 
         NineSlice* getBG();
-        cocos2d::CCLabelBMFont* getLabel();
+        geode::Label* getLabel();
         cocos2d::CCNodeRGBA* getContent();
 
     public:

--- a/loader/include/Geode/ui/Popup.hpp
+++ b/loader/include/Geode/ui/Popup.hpp
@@ -5,6 +5,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/ZStringView.hpp>
 #include <Geode/utils/function.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/Layout.hpp>
 #include <Geode/ui/NineSlice.hpp>
 
@@ -22,7 +23,7 @@ namespace geode {
     protected:
         cocos2d::CCSize m_size;
         NineSlice* m_bgSprite;
-        cocos2d::CCLabelBMFont* m_title = nullptr;
+        geode::Label* m_title = nullptr;
         CCMenuItemSpriteExtra* m_closeBtn;
 
         ~Popup();

--- a/loader/include/Geode/ui/ProgressBar.hpp
+++ b/loader/include/Geode/ui/ProgressBar.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <cocos2d.h>
 
+#include <Geode/ui/Label.hpp>
+
 namespace geode {
     // Enum for progress bar style
     enum class ProgressBarStyle {
@@ -74,7 +76,7 @@ namespace geode {
         /**
          * Get the progress percentage text label node
          */
-        cocos2d::CCLabelBMFont* getProgressLabel() const noexcept;
+        geode::Label* getProgressLabel() const noexcept;
 
         /**
          * Get the current style of the progress bar

--- a/loader/include/Geode/ui/SelectList.hpp
+++ b/loader/include/Geode/ui/SelectList.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Geode/binding/CCMenuItemSpriteExtra.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/function.hpp>
 
 namespace geode {
@@ -16,7 +17,7 @@ namespace geode {
         std::vector<T> m_list;
         size_t m_index = 0;
         geode::Function<void(T const&, size_t)> m_onChange;
-        cocos2d::CCLabelBMFont* m_label;
+        geode::Label* m_label;
         CCMenuItemSpriteExtra* m_prevBtn;
         CCMenuItemSpriteExtra* m_nextBtn;
 
@@ -47,7 +48,7 @@ namespace geode {
             m_nextBtn->setPosition(width / 2 - 10.f, 0.f);
             this->addChild(m_nextBtn);
 
-            m_label = cocos2d::CCLabelBMFont::create("", "bigFont.fnt");
+            m_label = geode::Label::create("", "bigFont.fnt");
             this->addChild(m_label);
 
             this->updateLabel();
@@ -59,7 +60,7 @@ namespace geode {
 
         void updateLabel() {
             if (m_list.size()) {
-                m_label->setString(Stringify(m_list.at(m_index)).c_str());
+                m_label->setText(Stringify(m_list.at(m_index)));
                 m_prevBtn->setEnabled(true);
                 m_nextBtn->setEnabled(true);
             }
@@ -68,7 +69,7 @@ namespace geode {
                 m_prevBtn->setEnabled(false);
                 m_nextBtn->setEnabled(false);
             }
-            m_label->limitLabelWidth(m_obContentSize.width - 40.f, .6f, .1f);
+            m_label->setLimitLabelWidth(m_obContentSize.width - 40.f, .6f, .1f);
         }
 
         void onPrev(CCObject* sender) {

--- a/loader/include/Geode/ui/SliderNode.hpp
+++ b/loader/include/Geode/ui/SliderNode.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/TextInput.hpp>
 #include <Geode/utils/function.hpp>
 #include <Geode/utils/ZStringView.hpp>
@@ -106,7 +107,7 @@ namespace geode {
          * Link a label. This will make the label automatically update whenever
          * the slider is dragged.
          */
-        void linkLabel(cocos2d::CCLabelBMFont* label, unsigned int precision);
+        void linkLabel(geode::Label* label, unsigned int precision);
 
         /**
          * Unlink a linked label
@@ -119,7 +120,7 @@ namespace geode {
         void setLabelPrecision(unsigned int precision);
 
         unsigned int getLabelPrecision();
-        cocos2d::CCLabelBMFont* getLinkedLabel();
+        geode::Label* getLinkedLabel();
 
         /**
          * Set the slider as read only. This will hide the thumb and will disallow edits made
@@ -159,7 +160,7 @@ namespace geode {
 
         bool initCustom(cocos2d::CCSprite* thumb, cocos2d::CCSprite* thumbSelected, NineSlice* groove, ZStringView bar, SliderCallback callback, cocos2d::CCSize const& barOffset);
         bool initStandard(SliderCallback callback, bool alt);
-        
+
         void updateSize();
         void updateFromTouch(cocos2d::CCTouch* touch);
 

--- a/loader/include/Geode/ui/TextArea.hpp
+++ b/loader/include/Geode/ui/TextArea.hpp
@@ -2,6 +2,7 @@
 
 #include <Geode/DefaultInclude.hpp>
 #include <Geode/utils/function.hpp>
+#include <Geode/ui/Label.hpp>
 #include <memory>
 #include <cocos2d.h>
 
@@ -50,7 +51,7 @@ namespace geode {
         float getScale() override;
         void setLinePadding(float padding);
         float getLinePadding();
-        std::vector<cocos2d::CCLabelBMFont*> getLines();
+        std::vector<geode::Label*> getLines();
         float getHeight();
         float getLineHeight();
 

--- a/loader/src/hooks/LoadingLayer.cpp
+++ b/loader/src/hooks/LoadingLayer.cpp
@@ -8,14 +8,15 @@
 #include <loader/console.hpp>
 #include <loader/updater.hpp>
 #include <Geode/utils/NodeIDs.hpp>
+#include <Geode/ui/Label.hpp>
 
 using namespace geode::prelude;
 
 struct CustomLoadingLayer : Modify<CustomLoadingLayer, LoadingLayer> {
     struct Fields {
         bool m_menuDisabled = false;
-        CCLabelBMFont* m_smallLabel = nullptr;
-        CCLabelBMFont* m_smallLabel2 = nullptr;
+        Label* m_smallLabel = nullptr;
+        Label* m_smallLabel2 = nullptr;
         int m_geodeLoadStep = 0;
         int m_totalMods = 0;
         ~Fields() {
@@ -72,13 +73,13 @@ struct CustomLoadingLayer : Modify<CustomLoadingLayer, LoadingLayer> {
 
         auto winSize = CCDirector::sharedDirector()->getWinSize();
 
-        m_fields->m_smallLabel = CCLabelBMFont::create("", "goldFont.fnt");
+        m_fields->m_smallLabel = Label::create("", "goldFont.fnt");
         m_fields->m_smallLabel->setPosition(winSize.width / 2, 30.f);
         m_fields->m_smallLabel->setScale(.45f);
         m_fields->m_smallLabel->setID("geode-small-label");
         this->addChild(m_fields->m_smallLabel);
 
-        m_fields->m_smallLabel2 = CCLabelBMFont::create("", "goldFont.fnt");
+        m_fields->m_smallLabel2 = Label::create("", "goldFont.fnt");
         m_fields->m_smallLabel2->setPosition(winSize.width / 2, 15.f);
         m_fields->m_smallLabel2->setScale(.45f);
         m_fields->m_smallLabel2->setID("geode-small-label-2");

--- a/loader/src/hooks/MenuLayer.cpp
+++ b/loader/src/hooks/MenuLayer.cpp
@@ -6,6 +6,7 @@
 #include <Geode/utils/NodeIDs.hpp>
 #include <Geode/ui/BasedButtonSprite.hpp>
 #include <Geode/ui/Notification.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/Popup.hpp>
 #include <Geode/ui/PopupManager.hpp>
 #include <Geode/ui/MDPopup.hpp>
@@ -302,7 +303,7 @@ struct CustomMenuLayer : Modify<CustomMenuLayer, MenuLayer> {
             icon->setScale(.65f);
 
             if (count > 0) {
-                auto countLabel = CCLabelBMFont::create(std::to_string(count).c_str(), "bigFont.fnt");
+                auto countLabel = Label::create(std::to_string(count), "bigFont.fnt");
                 countLabel->setScale(.5f);
                 icon->addChildAtPosition(countLabel, Anchor::Center);
             }

--- a/loader/src/ui/GeodeUI.cpp
+++ b/loader/src/ui/GeodeUI.cpp
@@ -4,6 +4,7 @@
 #include <Geode/ui/GeodeUI.hpp>
 #include <Geode/ui/MDPopup.hpp>
 #include <Geode/ui/LoadingSpinner.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/LazySprite.hpp>
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/utils/web.hpp>
@@ -346,7 +347,7 @@ protected:
 
     void onLoadFailed(bool postEvent) {
         // Fallback to default logo if the image failed to load
-        auto sprite = CCLabelBMFont::create("N/A", "bigFont.fnt");
+        auto sprite = Label::create("N/A", "bigFont.fnt");
         sprite->setPosition(this->getScaledContentSize() / 2.f + CCSize{1.f, 2.f});
         sprite->setOpacity(90);
         limitNodeSize(sprite, m_obContentSize, 99.f, 0.f);

--- a/loader/src/ui/mods/GeodeStyle.cpp
+++ b/loader/src/ui/mods/GeodeStyle.cpp
@@ -4,6 +4,7 @@
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/ui/LoadingSpinner.hpp>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/loader/Priority.hpp>
 
 $on_mod(Loaded) {
@@ -37,7 +38,7 @@ $on_mod(Loaded) {
     ColorProvider::get()->define("mod-problems-item-bg"_spr, { 255, 255, 255, 15 });
     ColorProvider::get()->define("mod-developer-item-bg"_spr, { 255, 255, 255, 15 });
     ColorProvider::get()->define("mod-list-paid-color"_spr, { 0, 255, 63, 255 });
-    
+
     ColorProvider::get()->define("keybinds-list-category-label"_spr, ccc3(148, 116, 155));
 
     // Only used when GD theme is active
@@ -364,8 +365,8 @@ bool GeodeTabSprite::init(const char* iconFrame, const char* text, float width, 
     limitNodeSize(m_icon, iconSize, 3.f, .1f);
     this->addChildAtPosition(m_icon, Anchor::Left, ccp(16, 0), false);
 
-    m_label = CCLabelBMFont::create(text, "bigFont.fnt");
-    m_label->limitLabelWidth(this->getContentWidth() - 45, std::clamp(width * .0045f, .35f, .55f), .1f);
+    m_label = Label::create(text, "bigFont.fnt");
+    m_label->setLimitLabelWidth(this->getContentWidth() - 45, std::clamp(width * .0045f, .35f, .55f), .1f);
     m_label->setAnchorPoint({ .5f, .5f });
     this->addChildAtPosition(m_label, Anchor::Left, ccp((itemSize.width - iconSize.width) / 2 + iconSize.width, 0), false);
 

--- a/loader/src/ui/mods/GeodeStyle.hpp
+++ b/loader/src/ui/mods/GeodeStyle.hpp
@@ -8,6 +8,7 @@
 #include <Geode/ui/Popup.hpp>
 #include <Geode/ui/ScrollLayer.hpp>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/ZStringView.hpp>
 #include <Geode/loader/Mod.hpp>
 #include <server/Server.hpp>
@@ -101,7 +102,7 @@ protected:
     NineSlice* m_deselectedBG;
     NineSlice* m_selectedBG;
     CCSprite* m_icon;
-    CCLabelBMFont* m_label;
+    geode::Label* m_label;
 
     bool init(const char* iconFrame, const char* text, float width, bool altColor);
 

--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -2,6 +2,7 @@
 #include <Geode/binding/CCMenuItemSpriteExtra.hpp>
 #include <Geode/loader/Dirs.hpp>
 #include <Geode/ui/BasedButtonSprite.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/file.hpp>
 #include <Geode/cocos/cocoa/CCObject.h>
 #include <Geode/loader/Event.hpp>
@@ -38,12 +39,12 @@ bool ModsStatusNode::init() {
     m_statusBG->setContentSize({ 570, 40 });
     m_statusBG->setScale(.5f);
 
-    m_status = CCLabelBMFont::create("", "bigFont.fnt");
+    m_status = Label::create("", "bigFont.fnt");
     m_status->setID("status-label");
     m_status->setScale(.8f);
     m_statusBG->addChildAtPosition(m_status, Anchor::Center);
 
-    m_statusPercentage = CCLabelBMFont::create("", "bigFont.fnt");
+    m_statusPercentage = Label::create("", "bigFont.fnt");
     m_statusPercentage->setID("status-percentage-label");
     m_statusPercentage->setScale(.8f);
     m_statusBG->addChildAtPosition(m_statusPercentage, Anchor::Right, ccp(-35, 0));
@@ -163,7 +164,7 @@ void ModsStatusNode::updateState() {
 
         // If some downloads were cancelled, show the restart button normally
         case DownloadState::SomeCancelled: {
-            m_status->setString("Download(s) Cancelled");
+            m_status->setText("Download(s) Cancelled");
             m_status->setColor(ccWHITE);
             m_status->setVisible(true);
 
@@ -174,10 +175,10 @@ void ModsStatusNode::updateState() {
         // but also a "all done" status
         case DownloadState::AllDone: {
             if (downloads.size() == 1) {
-                m_status->setString(fmt::format("{} Mod Installed/Updated", downloads.size()).c_str());
+                m_status->setText(fmt::format("{} Mod Installed/Updated", downloads.size()));
             }
             else {
-                m_status->setString(fmt::format("{} Mods Installed/Updated", downloads.size()).c_str());
+                m_status->setText(fmt::format("{} Mods Installed/Updated", downloads.size()));
             }
             m_status->setColor("mod-list-enabled"_cc3b);
             m_status->setVisible(true);
@@ -187,7 +188,7 @@ void ModsStatusNode::updateState() {
         } break;
 
         case DownloadState::SomeErrored: {
-            m_status->setString("Some Download(s) Failed");
+            m_status->setText("Some Download(s) Failed");
             m_status->setColor("mod-list-disabled"_cc3b);
             m_status->setVisible(true);
             m_statusBG->setVisible(true);
@@ -205,10 +206,10 @@ void ModsStatusNode::updateState() {
                 }
             }
             if (totalToConfirm == 1) {
-                m_status->setString(fmt::format("Click to Confirm {} Download", totalToConfirm).c_str());
+                m_status->setText(fmt::format("Click to Confirm {} Download", totalToConfirm));
             }
             else {
-                m_status->setString(fmt::format("Click to Confirm {} Downloads", totalToConfirm).c_str());
+                m_status->setText(fmt::format("Click to Confirm {} Downloads", totalToConfirm));
             }
             m_status->setColor(ccWHITE);
             m_status->setVisible(true);
@@ -220,7 +221,7 @@ void ModsStatusNode::updateState() {
         } break;
 
         case DownloadState::SomeFetching: {
-            m_status->setString("Preparing Download(s)");
+            m_status->setText("Preparing Download(s)");
             m_status->setColor(ccWHITE);
             m_status->setVisible(true);
             m_loadingCircle->setVisible(true);
@@ -241,7 +242,7 @@ void ModsStatusNode::updateState() {
             }
             auto percentage = totalProgress / static_cast<float>(totalDownloading);
 
-            m_statusPercentage->setString(fmt::format("{}%", static_cast<size_t>(percentage)).c_str());
+            m_statusPercentage->setText(fmt::format("{}%", static_cast<size_t>(percentage)));
             m_statusPercentage->setVisible(true);
             m_loadingCircle->setVisible(true);
             m_statusBG->setVisible(true);
@@ -617,7 +618,7 @@ bool ModsLayer::init() {
     m_pageMenu->setAnchorPoint({ 1.f, 1.f });
     m_pageMenu->setScale(.65f);
 
-    m_pageLabel = CCLabelBMFont::create("", "goldFont.fnt");
+    m_pageLabel = Label::create("", "goldFont.fnt");
     m_pageLabel->setID("page-label");
     m_pageLabel->setAnchorPoint({ .5f, 1.f });
     m_pageMenu->addChild(m_pageLabel);
@@ -667,7 +668,7 @@ bool ModsLayer::init() {
 
     // add safe mode label
     if (isSafeMode) {
-        auto* label = CCLabelBMFont::create("Safe Mode Enabled", "bigFont.fnt");
+        auto* label = Label::create("Safe Mode Enabled", "bigFont.fnt");
         label->setPosition(winSize.width, 0);
         label->setAnchorPoint(ccp(1, 0));
         label->setOpacity(128);
@@ -765,8 +766,7 @@ void ModsLayer::updateState() {
         auto total = m_currentSource->getItemCount().value();
 
         // Set the page count string
-        auto fmt = fmt::format("Page {}/{} (Total {})", page, count, total);
-        m_pageLabel->setString(fmt.c_str());
+        m_pageLabel->setText(fmt::format("Page {}/{} (Total {})", page, count, total));
 
         // Make page menu visible
         m_pageMenu->setVisible(true);

--- a/loader/src/ui/mods/ModsLayer.hpp
+++ b/loader/src/ui/mods/ModsLayer.hpp
@@ -5,6 +5,7 @@
 #include <Geode/ui/TextArea.hpp>
 #include <Geode/ui/IconButtonSprite.hpp>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/binding/SetTextPopupDelegate.hpp>
 #include <Geode/binding/SetIDPopupDelegate.hpp>
 #include <Geode/cocos/cocoa/CCObject.h>
@@ -30,8 +31,8 @@ protected:
     };
 
     NineSlice* m_statusBG;
-    CCLabelBMFont* m_status;
-    CCLabelBMFont* m_statusPercentage;
+    geode::Label* m_status;
+    geode::Label* m_statusPercentage;
     Slider* m_progressBar;
     CCNode* m_loadingCircle;
     CCMenu* m_btnMenu;
@@ -62,7 +63,7 @@ protected:
     ModListSource* m_currentSource = nullptr;
     std::unordered_map<ModListSource*, Ref<ModList>> m_lists;
     CCMenu* m_pageMenu;
-    CCLabelBMFont* m_pageLabel;
+    geode::Label* m_pageLabel;
     CCMenuItemSpriteExtra* m_goToPageBtn;
     ModsStatusNode* m_statusNode;
     ListenerHandle m_updateStateHandle;

--- a/loader/src/ui/mods/events/EventWinnerAnimation.cpp
+++ b/loader/src/ui/mods/events/EventWinnerAnimation.cpp
@@ -6,6 +6,7 @@
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/binding/CCMenuItemSpriteExtra.hpp>
 #include <Geode/ui/GeodeUI.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/cocos.hpp>
 
 static float shakeyNoise(float x) {
@@ -158,7 +159,7 @@ bool EventWinnerAnimation::init() {
             circleWave->m_color = ccc3(255, 255, 255);
             this->addChildAtPosition(circleWave, Anchor::Center);
 
-            auto modtoberWinnerLabel = CCLabelBMFont::create("Modtober Winner", "goldFont.fnt");
+            auto modtoberWinnerLabel = Label::create("Modtober Winner", "goldFont.fnt");
             float offset = 0.f;
             for (auto ch : CCArrayExt<CCNode*>(modtoberWinnerLabel->getChildren())) {
                 ch->setScale(0.f);
@@ -176,7 +177,7 @@ bool EventWinnerAnimation::init() {
             modtoberWinnerSpr->runAction(CCEaseInOut::create(CCScaleTo::create(.5f, .4f), 2.f));
             this->addChildAtPosition(modtoberWinnerSpr, Anchor::Center, ccp(0, 45));
 
-            auto winnerNameLabel = CCLabelBMFont::create("Geome3Dash", "bigFont.fnt");
+            auto winnerNameLabel = Label::create("Geome3Dash", "bigFont.fnt");
             winnerNameLabel->setScale(.7f);
             offset = 0.f;
             for (auto ch : CCArrayExt<CCNode*>(winnerNameLabel->getChildren())) {
@@ -190,7 +191,7 @@ bool EventWinnerAnimation::init() {
             }
             this->addChildAtPosition(winnerNameLabel, Anchor::Center, ccp(0, -50));
 
-            auto winnerDevLabel = CCLabelBMFont::create("Rainix & Adaf", "goldFont.fnt");
+            auto winnerDevLabel = Label::create("Rainix & Adaf", "goldFont.fnt");
             winnerDevLabel->setScale(.5f);
             offset = 0.f;
             for (auto ch : CCArrayExt<CCNode*>(winnerDevLabel->getChildren())) {

--- a/loader/src/ui/mods/list/ModDeveloperItem.cpp
+++ b/loader/src/ui/mods/list/ModDeveloperItem.cpp
@@ -2,9 +2,9 @@
 
 #include <Geode/cocos/base_nodes/CCNode.h>
 #include <Geode/ui/Layout.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/cocos/cocoa/CCGeometry.h>
-#include <Geode/cocos/label_nodes/CCLabelBMFont.h>
 #include <Geode/cocos/platform/CCPlatformMacros.h>
 #include <Geode/cocos/sprite_nodes/CCSprite.h>
 #include <Geode/DefaultInclude.hpp>
@@ -49,15 +49,15 @@ bool ModDeveloperItem::init(
         Anchor::Center
     );
 
-    auto label = CCLabelBMFont::create(
-        displayName.has_value() ? displayName->c_str() : developer.c_str(),
+    auto label = Label::create(
+        displayName.has_value() ? std::move(*displayName) : developer,
         "bigFont.fnt"
     );
 
     // Left + Right + Space between
     constexpr float paddings = 30.0f;
     float calc = size.width - paddings;
-    label->setWidth(calc);
+    label->setContentWidth(calc);
     label->setScale(0.4f);
     label->setAnchorPoint({0.0f, 0.5f});
 

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -12,6 +12,7 @@
 #include <Geode/loader/Loader.hpp>
 #include <Geode/ui/NineSlice.hpp>
 #include <Geode/ui/MDPopup.hpp>
+#include <Geode/ui/Label.hpp>
 #include <server/DownloadManager.hpp>
 #include <ui/mods/GeodeStyle.hpp>
 #include <ui/mods/popups/ModPopup.hpp>
@@ -46,11 +47,11 @@ bool ModItem::init(ModSource&& source, bool listItem) {
         title.append("...");
     }
 
-    m_titleLabel = CCLabelBMFont::create(title.c_str(), "bigFont.fnt");
+    m_titleLabel = Label::create(title.str(), "bigFont.fnt");
     m_titleLabel->setID("title-label");
     m_titleContainer->addChild(m_titleLabel);
 
-    m_versionLabel = CCLabelBMFont::create("", "bigFont.fnt");
+    m_versionLabel = Label::create("", "bigFont.fnt");
     m_versionLabel->setID("version-label");
     m_versionLabel->setScale(0.7f);
     m_versionLabel->setLayoutOptions(
@@ -60,7 +61,7 @@ bool ModItem::init(ModSource&& source, bool listItem) {
         );
     m_titleContainer->addChild(m_versionLabel);
 
-    m_versionDownloadSeparator = CCLabelBMFont::create("•", "bigFont.fnt");
+    m_versionDownloadSeparator = Label::create("•", "bigFont.fnt");
     m_versionDownloadSeparator->setOpacity(155);
     m_titleContainer->addChild(m_versionDownloadSeparator);
 
@@ -79,7 +80,7 @@ bool ModItem::init(ModSource&& source, bool listItem) {
     m_developers->setAnchorPoint({ .0f, .5f });
 
     auto by = m_source.formatDevelopers();
-    m_developerLabel = CCLabelBMFont::create(by.c_str(), "goldFont.fnt");
+    m_developerLabel = Label::create(by, "goldFont.fnt");
     m_developerLabel->setID("developers-label");
     auto developersBtn = CCMenuItemSpriteExtra::create(
         m_developerLabel, this, menu_selector(ModItem::onDevelopers)
@@ -101,8 +102,8 @@ bool ModItem::init(ModSource&& source, bool listItem) {
     m_description->setOpacity(90);
 
     auto desc = m_source.getMetadata().getDescription();
-    auto descLabel = CCLabelBMFont::create(
-        desc.value_or("[No Description Provided]").c_str(),
+    auto descLabel = Label::create(
+        desc.value_or("[No Description Provided]"),
         "chatFont.fnt"
     );
     descLabel->setColor(desc ? ccWHITE : ccGRAY);
@@ -172,7 +173,7 @@ bool ModItem::init(ModSource&& source, bool listItem) {
     m_downloadWaiting->setID("download-waiting-container");
     m_downloadWaiting->setContentSize({ 225, 30 });
 
-    auto downloadWaitingLabel = CCLabelBMFont::create("Preparing Download...", "bigFont.fnt");
+    auto downloadWaitingLabel = Label::create("Preparing Download...", "bigFont.fnt");
     downloadWaitingLabel->setScale(.75f);
     downloadWaitingLabel->setID("download-waiting-label");
     m_downloadWaiting->addChildAtPosition(
@@ -261,7 +262,7 @@ bool ModItem::init(ModSource&& source, bool listItem) {
                 }
 
                 m_pinToggle = CCMenuItemToggler::create(
-                    pinOff, pinOn, 
+                    pinOff, pinOn,
                     this, menu_selector(ModItem::onPin)
                 );
                 m_pinToggle->setScale(0.75f);
@@ -298,12 +299,12 @@ bool ModItem::init(ModSource&& source, bool listItem) {
             if (updatedAt) {
                 m_updatedAtContainer = CCNode::create();
 
-                auto installedLabel = CCLabelBMFont::create(
-                    utils::timeToAgoString(updatedAt->updateTime, true).c_str(),
+                auto installedLabel = Label::create(
+                    utils::timeToAgoString(updatedAt->updateTime, true),
                     "bigFont.fnt"
                 );
                 installedLabel->setID("installed-ago-label");
-                installedLabel->limitLabelWidth(125, 1.f, .1f);
+                installedLabel->setLimitLabelWidth(125, 1.f, .1f);
                 m_updatedAtContainer->addChildAtPosition(installedLabel, Anchor::Right, ccp(-0, 0), ccp(1, .5f));
 
                 auto installedIcon = CCSprite::createWithSpriteFrameName("GJ_timeIcon_001.png");
@@ -372,13 +373,13 @@ bool ModItem::init(ModSource&& source, bool listItem) {
             // on which mods to install
             m_downloadCountContainer = CCNode::create();
 
-            auto downloads = CCLabelBMFont::create(
-                numToAbbreviatedString(metadata.downloadCount).c_str(),
+            auto downloads = Label::create(
+                numToAbbreviatedString(metadata.downloadCount),
                 "bigFont.fnt"
             );
             downloads->setID("downloads-label");
             downloads->setColor("mod-list-version-label"_cc3b);
-            downloads->limitLabelWidth(125, 1.f, .1f);
+            downloads->setLimitLabelWidth(125, 1.f, .1f);
             m_downloadCountContainer->addChildAtPosition(downloads, Anchor::Right, ccp(-0, 0), ccp(1, .5f));
 
             auto downloadsIcon = CCSprite::createWithSpriteFrameName("GJ_downloadsIcon_001.png");
@@ -414,7 +415,7 @@ bool ModItem::init(ModSource&& source, bool listItem) {
             //         m_recommendedBy = CCNode::create();
             //         m_recommendedBy->setID("recommended-container");
             //         m_recommendedBy->setContentWidth(225);
-            //         auto byLabel = CCLabelBMFont::create("Recommended by ", "bigFont.fnt");
+            //         auto byLabel = Label::create("Recommended by ", "bigFont.fnt");
             //         byLabel->setID("recommended-label");
             //         byLabel->setColor("mod-list-recommended-by"_cc3b);
             //         m_recommendedBy->addChild(byLabel);
@@ -426,7 +427,7 @@ bool ModItem::init(ModSource&& source, bool listItem) {
             //             recommendStr = fmt::format("{} installed mods", recommends.size());
             //         }
 
-            //         auto nameLabel = CCLabelBMFont::create(recommendStr.c_str(), "bigFont.fnt");
+            //         auto nameLabel = Label::create(recommendStr.c_str(), "bigFont.fnt");
             //         nameLabel->setID("recommended-name-label");
             //         nameLabel->setColor("mod-list-recommended-by-2"_cc3b);
             //         m_recommendedBy->addChild(nameLabel);
@@ -513,8 +514,8 @@ void ModItem::updateState() {
         }
     }
 
-    // Show the "Updated at" label if the installed mods list is being sorted 
-    // by "Recently installed" (to let people know when they've installed or 
+    // Show the "Updated at" label if the installed mods list is being sorted
+    // by "Recently installed" (to let people know when they've installed or
     // updated the mod)
     // Hide the enable and pin toggles to make space for install times :3
     // (Pinning doesn't make sense for that sorting anyway)
@@ -679,9 +680,7 @@ void ModItem::updateState() {
         if (update.update) {
             m_updateBtn->setVisible(true);
 
-            std::string updateString = "";
-            updateString += m_source.getMetadata().getVersion().toVString() + " -> " + update.update->version.toVString();
-            m_versionLabel->setString(updateString.c_str());
+            m_versionLabel->setText(fmt::format("{} -> {}", m_source.getMetadata().getVersion().toVString(), update.update->version.toVString()));
             m_versionLabel->setColor(to3B(ColorProvider::get()->color("mod-list-version-label-updates-available"_spr)));
 
             m_bg->setColor(to3B(ColorProvider::get()->color("mod-list-version-bg-updates-available"_spr)));
@@ -695,7 +694,7 @@ void ModItem::updateState() {
         }
     }
     else {
-        m_versionLabel->setString(m_source.getMetadata().getVersion().toVString().c_str());
+        m_versionLabel->setText(m_source.getMetadata().getVersion().toVString());
         m_versionLabel->setColor(to3B(ColorProvider::get()->color("mod-list-version-label"_spr)));
     }
 
@@ -1034,7 +1033,7 @@ bool AnyModItem::init(ZStringView modID) {
 
                     m_bg->setColor(ccRED);
                     m_bg->setOpacity(90);
-                    auto errorLabel = CCLabelBMFont::create(err.details.c_str(), "bigFont.fnt");
+                    auto errorLabel = Label::create(std::move(err.details), "bigFont.fnt");
                     errorLabel->setAnchorPoint(ccp(0, .5f));
                     errorLabel->setScale(.35f);
                     this->addChildAtPosition(errorLabel, Anchor::Left, ccp(10, 0));

--- a/loader/src/ui/mods/list/ModItem.hpp
+++ b/loader/src/ui/mods/list/ModItem.hpp
@@ -6,6 +6,7 @@
 #include <Geode/binding/Slider.hpp>
 #include <Geode/binding/CCMenuItemToggler.hpp>
 #include <Geode/binding/CCMenuItemSpriteExtra.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/LoadingSpinner.hpp>
 #include <Geode/ui/NineSlice.hpp>
 #include <server/DownloadManager.hpp>
@@ -54,12 +55,12 @@ protected:
     CCNode* m_logo;
     CCNode* m_infoContainer;
     CCNode* m_titleContainer;
-    Ref<CCLabelBMFont> m_titleLabel;
-    CCLabelBMFont* m_versionLabel;
+    Ref<Label> m_titleLabel;
+    Label* m_versionLabel;
     CCNode* m_developers;
     CCNode* m_recommendedBy;
     NineSlice* m_description;
-    CCLabelBMFont* m_developerLabel;
+    Label* m_developerLabel;
     ButtonSprite* m_restartRequiredLabel;
     ButtonSprite* m_outdatedLabel;
     ButtonSprite* m_deprecatedLabel;
@@ -78,7 +79,7 @@ protected:
     Ref<CCNode> m_badgeContainer = nullptr;
     Ref<CCNode> m_downloadCountContainer;
     Ref<CCNode> m_updatedAtContainer;
-    CCLabelBMFont* m_versionDownloadSeparator;
+    Label* m_versionDownloadSeparator;
 
     /**
      * @warning Make sure `getMetadata` and `createModLogo` are callable
@@ -104,7 +105,7 @@ public:
 };
 
 /**
- * Standalone ModItem that you give a Mod ID to and it'll either show the mod 
+ * Standalone ModItem that you give a Mod ID to and it'll either show the mod
  * if it's installed or fetch from server if it is not
  */
 class AnyModItem : public ModListItem {

--- a/loader/src/ui/mods/list/ModList.cpp
+++ b/loader/src/ui/mods/list/ModList.cpp
@@ -3,6 +3,7 @@
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/ui/GeodeUI.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/TextInput.hpp>
 #include <Geode/ui/SimpleAxisLayout.hpp>
 #include <Geode/ui/Notification.hpp>
@@ -290,7 +291,7 @@ bool ModList::init(ModListSource* src, CCSize const& size, bool searchingDev) {
         limitNodeWidth(banner, size.width, 1.f, .1f);
         menu->addChildAtPosition(banner, Anchor::Center);
 
-        auto label = CCLabelBMFont::create("Modtober 2025 is Here!", "bigFont.fnt");
+        auto label = Label::create("Modtober 2025 is Here!", "bigFont.fnt");
         label->setScale(.5f);
         menu->addChildAtPosition(label, Anchor::Left, ccp(10, 0), ccp(0, .5f));
 
@@ -375,9 +376,9 @@ bool ModList::init(ModListSource* src, CCSize const& size, bool searchingDev) {
     m_statusContainer->setAnchorPoint({ .5f, .5f });
     m_statusContainer->ignoreAnchorPointForPosition(false);
 
-    m_statusTitle = CCLabelBMFont::create("", "bigFont.fnt");
+    m_statusTitle = Label::create("", "bigFont.fnt");
     m_statusTitle->setID("status-title-label");
-    m_statusTitle->setAlignment(kCCTextAlignmentCenter);
+    m_statusTitle->setAlignment(Label::Alignment::Center);
     m_statusContainer->addChild(m_statusTitle);
 
     m_statusDetailsBtn = CCMenuItemSpriteExtra::create(
@@ -732,7 +733,7 @@ void ModList::showStatus(ModListStatus status, ZStringView message, std::optiona
 
     // Update status
     bool hasDetails = details.has_value();
-    m_statusTitle->setString(message.c_str());
+    m_statusTitle->setText(message);
     m_statusDetails->setText(std::move(details).value_or(""));
 
     // Update status visibility

--- a/loader/src/ui/mods/list/ModList.hpp
+++ b/loader/src/ui/mods/list/ModList.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Geode/ui/General.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/ScrollLayer.hpp>
 #include <Geode/ui/TextArea.hpp>
 #include <Geode/ui/TextInput.hpp>
@@ -27,7 +28,7 @@ protected:
     size_t m_page = 0;
     ScrollLayer* m_list;
     CCMenu* m_statusContainer;
-    CCLabelBMFont* m_statusTitle;
+    Label* m_statusTitle;
     SimpleTextArea* m_statusDetails;
     CCMenuItemSpriteExtra* m_statusDetailsBtn;
     CCNode* m_statusLoadingCircle;

--- a/loader/src/ui/mods/popups/ConfirmUninstallPopup.cpp
+++ b/loader/src/ui/mods/popups/ConfirmUninstallPopup.cpp
@@ -1,6 +1,7 @@
 #include "ConfirmUninstallPopup.hpp"
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/binding/TextArea.hpp>
+#include <Geode/ui/Label.hpp>
 
 bool ConfirmUninstallPopup::init(Mod* mod) {
     if (!Popup::init(300.f, 150.f, "square01_001.png"))
@@ -18,12 +19,12 @@ bool ConfirmUninstallPopup::init(Mod* mod) {
     );
     m_mainLayer->addChildAtPosition(text, Anchor::Center, ccp(0, 20));
 
-    auto deleteDataLabel = CCLabelBMFont::create("Delete the Mod's save data", "bigFont.fnt");
+    auto deleteDataLabel = Label::create("Delete the Mod's save data", "bigFont.fnt");
     deleteDataLabel->setScale(.35f);
     m_buttonMenu->addChildAtPosition(deleteDataLabel, Anchor::Center, ccp(-70, -15), ccp(0, .5f));
 
     if (mod->isInternal()) {
-        deleteDataLabel->setString("Delete ALL mods and their save data");
+        deleteDataLabel->setText("Delete ALL mods and their save data");
         deleteDataLabel->setScale(0.275f);
     }
 

--- a/loader/src/ui/mods/popups/DevPopup.cpp
+++ b/loader/src/ui/mods/popups/DevPopup.cpp
@@ -11,7 +11,7 @@ bool DevListPopup::init(ModSource meta) {
     m_source = std::move(meta);
 
     this->setTitle(fmt::format("Developers for {}", m_source.getMetadata().getName()));
-    m_title->limitLabelWidth(m_size.width - 50, .7f, .1f);
+    m_title->setLimitLabelWidth(m_size.width - 50, .7f, .1f);
 
     ModDeveloperList* list = ModDeveloperList::create(this, m_source, {210.f, 150.f});
     m_mainLayer->addChildAtPosition(

--- a/loader/src/ui/mods/popups/FiltersPopup.cpp
+++ b/loader/src/ui/mods/popups/FiltersPopup.cpp
@@ -1,5 +1,7 @@
 #include "FiltersPopup.hpp"
 
+#include <Geode/ui/Label.hpp>
+
 bool FiltersPopup::init(ModListSource* src) {
     float height = 170;
     if (typeinfo_cast<InstalledModListSource*>(src) || typeinfo_cast<ServerModListSource*>(src)) {
@@ -43,7 +45,7 @@ bool FiltersPopup::init(ModListSource* src) {
     tagsTitleMenu->setAnchorPoint({ .5f, 0 });
     tagsTitleMenu->setContentWidth(tagsContainer->getContentWidth());
 
-    auto tagsTitle = CCLabelBMFont::create("Tags", "bigFont.fnt");
+    auto tagsTitle = Label::create("Tags", "bigFont.fnt");
     tagsTitleMenu->addChild(tagsTitle);
 
     tagsTitleMenu->addChild(SpacerNode::create());
@@ -85,7 +87,7 @@ bool FiltersPopup::init(ModListSource* src) {
         m_enabledModsOnly->toggle(src->getQuery().enabledOnly.value_or(false));
         optionsMenu->addChild(m_enabledModsOnly);
 
-        auto enabledOnlyLabel = CCLabelBMFont::create("Enabled Only", "bigFont.fnt");
+        auto enabledOnlyLabel = Label::create("Enabled Only", "bigFont.fnt");
         enabledOnlyLabel->setScale(.35f);
         optionsMenu->addChild(enabledOnlyLabel);
 
@@ -94,7 +96,7 @@ bool FiltersPopup::init(ModListSource* src) {
         m_enabledModsFirst->setLayoutOptions(AxisLayoutOptions::create()->setPrevGap(10.f));
         optionsMenu->addChild(m_enabledModsFirst);
 
-        auto enabledFirstLabel = CCLabelBMFont::create("Enabled First", "bigFont.fnt");
+        auto enabledFirstLabel = Label::create("Enabled First", "bigFont.fnt");
         enabledFirstLabel->setScale(.35f);
         optionsMenu->addChild(enabledFirstLabel);
 
@@ -106,7 +108,7 @@ bool FiltersPopup::init(ModListSource* src) {
         optionsTitleMenu->setAnchorPoint({ .5f, 0 });
         optionsTitleMenu->setContentWidth(optionsContainer->getContentWidth());
 
-        auto optionsTitle = CCLabelBMFont::create("Options", "bigFont.fnt");
+        auto optionsTitle = Label::create("Options", "bigFont.fnt");
         optionsTitleMenu->addChild(optionsTitle);
 
         optionsTitleMenu->addChild(SpacerNode::create());
@@ -134,7 +136,7 @@ bool FiltersPopup::init(ModListSource* src) {
         inputTitleMenu->setAnchorPoint({ .5f, 0 });
         inputTitleMenu->setContentWidth(inputContainer->getContentWidth());
 
-        auto inputTitle = CCLabelBMFont::create("From Developer", "bigFont.fnt");
+        auto inputTitle = Label::create("From Developer", "bigFont.fnt");
         inputTitleMenu->addChild(inputTitle);
 
         inputTitleMenu->addChild(SpacerNode::create());
@@ -192,7 +194,7 @@ void FiltersPopup::onLoadTags(server::ServerResult<std::vector<server::ServerTag
     }
     else {
         m_tagsMenu->removeAllChildren();
-        auto label = CCLabelBMFont::create("Unable to load tags", "bigFont.fnt");
+        auto label = Label::create("Unable to load tags", "bigFont.fnt");
         label->setOpacity(105);
         m_tagsMenu->addChild(label);
         m_tagsMenu->updateLayout();

--- a/loader/src/ui/mods/popups/ModPopup.cpp
+++ b/loader/src/ui/mods/popups/ModPopup.cpp
@@ -5,6 +5,7 @@
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/ui/MDTextArea.hpp>
 #include <Geode/ui/TextInput.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/web.hpp>
 #include <Geode/loader/Event.hpp>
 #include <Geode/loader/Loader.hpp>
@@ -96,8 +97,7 @@ bool ModPopup::init(ModSource&& src) {
         auto loaderHash = about::getLoaderCommitHash();
         auto bindingsHash = about::getBindingsCommitHash();
 
-        auto string = fmt::format("Loader: {}, Bindings: {}", loaderHash, bindingsHash);
-        auto hashLabel = CCLabelBMFont::create(string.c_str(), "chatFont.fnt");
+        auto hashLabel = Label::create(fmt::format("Loader: {}, Bindings: {}", loaderHash, bindingsHash), "chatFont.fnt");
         hashLabel->setAnchorPoint({ .5f, 1.f });
         hashLabel->setOpacity(51);
         hashLabel->setScale(.7f);
@@ -161,15 +161,14 @@ bool ModPopup::init(ModSource&& src) {
         title.append("...");
     }
 
-    auto titleLabel = CCLabelBMFont::create(title.c_str(), "bigFont.fnt");
-    titleLabel->limitLabelWidth(m_titleContainer->getContentWidth() - devAndTitlePos, .45f, .1f);
+    auto titleLabel = Label::create(title.str(), "bigFont.fnt");
+    titleLabel->setLimitLabelWidth(m_titleContainer->getContentWidth() - devAndTitlePos, .45f, .1f);
     titleLabel->setAnchorPoint({ .0f, .5f });
     titleLabel->setID("mod-name-label");
     m_titleContainer->addChildAtPosition(titleLabel, Anchor::TopLeft, ccp(devAndTitlePos, -m_titleContainer->getContentHeight() * .25f));
 
-    auto by = "By " + m_source.formatDevelopers();
-    auto dev = CCLabelBMFont::create(by.c_str(), "goldFont.fnt");
-    dev->limitLabelWidth(m_titleContainer->getContentWidth() - devAndTitlePos, .35f, .05f);
+    auto dev = Label::create(fmt::format("By {}", m_source.formatDevelopers()), "goldFont.fnt");
+    dev->setLimitLabelWidth(m_titleContainer->getContentWidth() - devAndTitlePos, .35f, .05f);
     dev->setAnchorPoint({ .0f, .5f });
     dev->setID("mod-developer-label");
     m_titleContainer->addChildAtPosition(dev, Anchor::BottomLeft, ccp(devAndTitlePos, m_titleContainer->getContentHeight() * .25f));
@@ -194,7 +193,7 @@ bool ModPopup::init(ModSource&& src) {
     //         recommendedBy->setContentWidth(m_titleContainer->getContentWidth() - devAndTitlePos);
     //         recommendedBy->setAnchorPoint({ .0f, .5f });
 
-    //         auto byLabel = CCLabelBMFont::create("Recommended by ", "bigFont.fnt");
+    //         auto byLabel = Label::create("Recommended by ", "bigFont.fnt");
     //         byLabel->setColor("mod-list-recommended-by"_cc3b);
     //         recommendedBy->addChild(byLabel);
 
@@ -205,7 +204,7 @@ bool ModPopup::init(ModSource&& src) {
     //             suggestionStr = fmt::format("{} installed mods", recommends.size());
     //         }
 
-    //         auto nameLabel = CCLabelBMFont::create(suggestionStr.c_str(), "bigFont.fnt");
+    //         auto nameLabel = Label::create(suggestionStr.c_str(), "bigFont.fnt");
     //         nameLabel->setColor("mod-list-recommended-by-2"_cc3b);
     //         recommendedBy->addChild(nameLabel);
 
@@ -220,9 +219,8 @@ bool ModPopup::init(ModSource&& src) {
 
     leftColumn->addChild(m_titleContainer);
 
-    auto idStr = "(ID: " + m_source.getMetadata().getID() + ")";
-    auto idLabel = CCLabelBMFont::create(idStr.c_str(), "bigFont.fnt");
-    idLabel->limitLabelWidth(leftColumn->getContentWidth(), .25f, .05f);
+    auto idLabel = Label::create(fmt::format("(ID: {})", m_source.getMetadata().getID()), "bigFont.fnt");
+    idLabel->setLimitLabelWidth(leftColumn->getContentWidth(), .25f, .05f);
     idLabel->setColor({ 150, 150, 150 });
     idLabel->setOpacity(140);
     idLabel->setID("mod-id-label");
@@ -269,13 +267,13 @@ bool ModPopup::init(ModSource&& src) {
         );
         container->addChildAtPosition(labelContainer, Anchor::Right);
 
-        auto label = CCLabelBMFont::create("", "bigFont.fnt");
+        auto label = Label::create("", "bigFont.fnt");
         label->setID("label");
         labelContainer->addChild(label);
 
         labelContainer->addChild(SpacerNode::create());
 
-        auto valueLabel = CCLabelBMFont::create("", "bigFont.fnt");
+        auto valueLabel = Label::create("", "bigFont.fnt");
         valueLabel->setID("value-label");
         labelContainer->addChild(valueLabel);
 
@@ -300,8 +298,8 @@ bool ModPopup::init(ModSource&& src) {
 
     // Tags
 
-    auto tagsTitle = CCLabelBMFont::create("Tags", "bigFont.fnt");
-    tagsTitle->limitLabelWidth(leftColumn->getContentWidth(), .25f, .05f);
+    auto tagsTitle = Label::create("Tags", "bigFont.fnt");
+    tagsTitle->setLimitLabelWidth(leftColumn->getContentWidth(), .25f, .05f);
     tagsTitle->setOpacity(195);
     tagsTitle->setID("tags-title");
     leftColumn->addChild(tagsTitle);
@@ -342,7 +340,7 @@ bool ModPopup::init(ModSource&& src) {
     auto manageContainer = CCNode::create();
     manageContainer->setContentSize({ leftColumn->getContentWidth(), 10 });
 
-    auto manageTitle = CCLabelBMFont::create("Manage", "bigFont.fnt");
+    auto manageTitle = Label::create("Manage", "bigFont.fnt");
     manageTitle->setScale(.25f);
     manageTitle->setOpacity(195);
     manageTitle->setID("manage-title");
@@ -358,7 +356,7 @@ bool ModPopup::init(ModSource&& src) {
     m_restartRequiredLabel->setScale(.3f);
     manageContainer->addChildAtPosition(m_restartRequiredLabel, Anchor::Right, ccp(0, 0), ccp(1, .5f));
 
-    m_enabledStatusLabel = CCLabelBMFont::create("", "bigFont.fnt");
+    m_enabledStatusLabel = Label::create("", "bigFont.fnt");
     m_enabledStatusLabel->setScale(.25f);
     m_enabledStatusLabel->setOpacity(140);
     m_enabledStatusLabel->setID("enabled-status");
@@ -490,7 +488,7 @@ bool ModPopup::init(ModSource&& src) {
     m_cancelBtn->setID("cancel-button");
     m_installMenu->addChild(m_cancelBtn);
 
-    m_installStatusLabel = CCLabelBMFont::create("", "bigFont.fnt");
+    m_installStatusLabel = Label::create("", "bigFont.fnt");
     m_installStatusLabel->setOpacity(120);
     m_installStatusLabel->setVisible(false);
     m_installMenu->addChild(m_installStatusLabel);
@@ -764,11 +762,11 @@ void ModPopup::updateState() {
 
     if (!wantsRestart && asMod) {
         if (asMod->isLoaded()) {
-            m_enabledStatusLabel->setString("Enabled");
+            m_enabledStatusLabel->setText("Enabled");
             m_enabledStatusLabel->setColor(to3B(ColorProvider::get()->color("mod-list-enabled"_spr)));
         }
         else {
-            m_enabledStatusLabel->setString("Disabled");
+            m_enabledStatusLabel->setText("Disabled");
             m_enabledStatusLabel->setColor(to3B(ColorProvider::get()->color("mod-list-disabled"_spr)));
         }
         m_enabledStatusLabel->setVisible(true);
@@ -798,11 +796,11 @@ void ModPopup::updateState() {
     m_uninstallBtn->setVisible(asMod && asMod->getRequestedAction() == ModRequestedAction::None);
 
     if (asMod && modRequestedActionIsUninstall(asMod->getRequestedAction())) {
-        m_installStatusLabel->setString("Mod has been uninstalled");
+        m_installStatusLabel->setText("Mod has been uninstalled");
         m_installStatusLabel->setVisible(true);
     }
     else {
-        m_installStatusLabel->setString("");
+        m_installStatusLabel->setText("");
         m_installStatusLabel->setVisible(false);
     }
 
@@ -824,7 +822,7 @@ void ModPopup::updateState() {
         // you can uninstall loader ingame just fine on windows
         #if !defined(GEODE_IS_WINDOWS)
         m_uninstallBtn->setVisible(false);
-        m_installStatusLabel->setString("N/A");
+        m_installStatusLabel->setText("N/A");
         m_installStatusLabel->setVisible(true);
         #endif
     }
@@ -841,12 +839,12 @@ void ModPopup::updateState() {
 
             auto status = download->getStatus();
             if (auto d = std::get_if<server::DownloadStatusDownloading>(&status)) {
-                m_enabledStatusLabel->setString(fmt::format("Downloading {}%", d->percentage).c_str());
+                m_enabledStatusLabel->setText(fmt::format("Downloading {}%", d->percentage));
                 m_enabledStatusLabel->setColor(ccWHITE);
                 // todo: progress bar
             }
             else {
-                m_enabledStatusLabel->setString("Preparing");
+                m_enabledStatusLabel->setText("Preparing");
                 m_enabledStatusLabel->setColor(ccWHITE);
                 // todo: spinner
             }
@@ -854,12 +852,12 @@ void ModPopup::updateState() {
         else {
             std::visit(makeVisitor {
                 [this](server::DownloadStatusError const& e) {
-                    m_enabledStatusLabel->setString("Error");
+                    m_enabledStatusLabel->setText("Error");
                     m_enabledStatusLabel->setColor(to3B(ColorProvider::get()->color("mod-list-disabled"_spr)));
                     // todo: show error details somewhere (like an info button)
                 },
                 [this](server::DownloadStatusCancelled const&) {
-                    m_enabledStatusLabel->setString("Cancelled");
+                    m_enabledStatusLabel->setText("Cancelled");
                     m_enabledStatusLabel->setColor(to3B(ColorProvider::get()->color("mod-list-disabled"_spr)));
                 },
                 [this](server::DownloadStatusDone const&) {
@@ -870,7 +868,7 @@ void ModPopup::updateState() {
                     m_uninstallBtn->setVisible(false);
                     m_cancelBtn->setVisible(false);
 
-                    m_installStatusLabel->setString("Mod has been installed");
+                    m_installStatusLabel->setText("Mod has been installed");
                     m_installStatusLabel->setVisible(true);
                 },
                 // rest are unreachable due to the isActive() check
@@ -902,8 +900,8 @@ void ModPopup::setStatLabel(CCNode* stat, ZStringView value, bool noValue, ccCol
     auto container = stat->getChildByID("labels");
 
     // Update label
-    auto label = static_cast<CCLabelBMFont*>(container->getChildByID("label"));
-    label->setString(value.c_str());
+    auto label = static_cast<Label*>(container->getChildByID("label"));
+    label->setText(value);
     label->setColor(color);
 
     // Remove value if requested
@@ -917,7 +915,7 @@ void ModPopup::setStatLabel(CCNode* stat, ZStringView value, bool noValue, ccCol
 
 void ModPopup::setStatValue(CCNode* stat, std::optional<std::string> const& value) {
     auto container = stat->getChildByID("labels");
-    auto valueLabel = static_cast<CCLabelBMFont*>(container->getChildByID("value-label"));
+    auto valueLabel = static_cast<Label*>(container->getChildByID("value-label"));
     auto spinner = container->getChildByID("loading-spinner");
 
     // Show loading if no value provided
@@ -926,7 +924,7 @@ void ModPopup::setStatValue(CCNode* stat, std::optional<std::string> const& valu
 
     // Update value
     if (value) {
-        valueLabel->setString(value.value().c_str());
+        valueLabel->setText(value.value());
     }
 
     // Update layout
@@ -1019,7 +1017,7 @@ void ModPopup::onLoadTags(server::ServerResult<std::vector<server::ServerTag>> r
         }
 
         if (data.empty()) {
-            auto label = CCLabelBMFont::create("No tags found", "bigFont.fnt");
+            auto label = Label::create("No tags found", "bigFont.fnt");
             label->setOpacity(120);
             m_tags->addChild(label);
         }
@@ -1039,7 +1037,7 @@ void ModPopup::onLoadTags(server::ServerResult<std::vector<server::ServerTag>> r
             limitNodeWidth(banner, m_rightColumn->getContentWidth(), 1.f, .1f);
             menu->addChildAtPosition(banner, Anchor::Center);
 
-            auto label = CCLabelBMFont::create(("Entry for Modtober 20" + year).c_str(), "bigFont.fnt");
+            auto label = Label::create(fmt::format("Entry for Modtober 20{}", year), "bigFont.fnt");
             label->setScale(.35f);
             menu->addChildAtPosition(label, Anchor::Left, ccp(10, 0), ccp(0, .5f));
 
@@ -1076,7 +1074,7 @@ void ModPopup::onLoadTags(server::ServerResult<std::vector<server::ServerTag>> r
     else {
         m_tags->removeAllChildren();
 
-        auto label = CCLabelBMFont::create("No tags found", "bigFont.fnt");
+        auto label = Label::create("No tags found", "bigFont.fnt");
         label->setOpacity(120);
         m_tags->addChild(label);
 

--- a/loader/src/ui/mods/popups/ModPopup.hpp
+++ b/loader/src/ui/mods/popups/ModPopup.hpp
@@ -3,6 +3,7 @@
 #include <Geode/ui/Popup.hpp>
 #include <Geode/ui/MDTextArea.hpp>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 #include "../sources/ModSource.hpp"
 #include "../GeodeStyle.hpp"
 #include "../UpdateModListState.hpp"
@@ -30,10 +31,10 @@ protected:
     CCMenuItemSpriteExtra* m_unavailableBtn;
     CCMenuItemSpriteExtra* m_updateBtn;
     CCMenuItemSpriteExtra* m_cancelBtn;
-    CCLabelBMFont* m_installStatusLabel;
+    geode::Label* m_installStatusLabel;
     NineSlice* m_installBG;
     NineSlice* m_settingsBG;
-    CCLabelBMFont* m_enabledStatusLabel;
+    geode::Label* m_enabledStatusLabel;
     ButtonSprite* m_restartRequiredLabel;
     CCNode* m_rightColumn;
     CCNode* m_currentTabPage = nullptr;

--- a/loader/src/ui/mods/popups/SortPopup.cpp
+++ b/loader/src/ui/mods/popups/SortPopup.cpp
@@ -1,9 +1,11 @@
 #include "SortPopup.hpp"
 
+#include <Geode/ui/Label.hpp>
+
 bool SortPopup::init(ModListSource* src) {
     if (!GeodePopup::init(230.f, 165.f))
         return false;
-    
+
     m_noElasticity = true;
     m_source = src;
 
@@ -12,7 +14,7 @@ bool SortPopup::init(ModListSource* src) {
     auto container = CCNode::create();
     container->setContentSize({ 200, 115 });
 
-    for (auto const& [sort, name] : src->getSortingOptions()) {
+    for (auto& [sort, name] : src->getSortingOptions()) {
         auto node = CCMenu::create();
         node->setContentSize({ container->getContentWidth(), 22 });
 
@@ -28,7 +30,7 @@ bool SortPopup::init(ModListSource* src) {
         node->addChildAtPosition(toggle, Anchor::Left, ccp(15, 0));
         m_options.push_back(toggle);
 
-        auto label = CCLabelBMFont::create(name.c_str(), "bigFont.fnt");
+        auto label = Label::create(std::move(name), "bigFont.fnt");
         label->setScale(.5f);
         node->addChildAtPosition(label, Anchor::Left, ccp(30, 0), ccp(0, .5f));
 

--- a/loader/src/ui/mods/settings/KeybindEditPopup.cpp
+++ b/loader/src/ui/mods/settings/KeybindEditPopup.cpp
@@ -1,5 +1,6 @@
 #include "KeybindEditPopup.hpp"
 
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/Scrollbar.hpp>
 #include <Geode/ui/SimpleAxisLayout.hpp>
 
@@ -22,7 +23,7 @@ bool KeybindEditPopup::init(
     m_noElasticity = true;
 
     if (auto mod = setting->getMod()) {
-        auto fromModLabel = CCLabelBMFont::create(mod->getName().c_str(), "bigFont.fnt");
+        auto fromModLabel = Label::create(mod->getName(), "bigFont.fnt");
         fromModLabel->setScale(.4f);
         fromModLabel->setColor(ccc3(55, 155, 255));
         m_mainLayer->addChildAtPosition(fromModLabel, Anchor::Top, ccp(0, -40));
@@ -88,14 +89,14 @@ void KeybindEditPopup::updateLabel() {
             m_originalKeybindContainer->setScale(.4f);
             m_originalKeybindContainer->setAnchorPoint(ccp(.5f, .5f));
 
-            auto originalKeybindInfoStart = CCLabelBMFont::create("(Previous: ", "bigFont.fnt");
+            auto originalKeybindInfoStart = Label::create("(Previous: ", "bigFont.fnt");
             originalKeybindInfoStart->setColor(ccc3(55, 255, 55));
             m_originalKeybindContainer->addChild(originalKeybindInfoStart);
 
             auto originalKeybind = m_originalKeybind->createNode();
             m_originalKeybindContainer->addChild(originalKeybind);
-            
-            auto originalKeybindInfoEnd = CCLabelBMFont::create(")", "bigFont.fnt");
+
+            auto originalKeybindInfoEnd = Label::create(")", "bigFont.fnt");
             originalKeybindInfoEnd->setColor(ccc3(55, 255, 55));
             m_originalKeybindContainer->addChild(originalKeybindInfoEnd);
 
@@ -108,7 +109,7 @@ void KeybindEditPopup::updateLabel() {
         m_keybindNode->removeFromParent();
     }
     if (m_currentKeybind.key == KEY_None && m_currentKeybind.modifiers == KeyboardModifier::None) {
-        auto label = CCLabelBMFont::create("Press a key...", "bigFont.fnt");
+        auto label = Label::create("Press a key...", "bigFont.fnt");
         label->setOpacity(150);
         label->setScale(.75f);
         m_keybindNode = label;

--- a/loader/src/ui/mods/settings/SettingNodeV3.cpp
+++ b/loader/src/ui/mods/settings/SettingNodeV3.cpp
@@ -5,6 +5,7 @@
 #include <Geode/ui/MDPopup.hpp>
 #include <Geode/ui/Scrollbar.hpp>
 #include <Geode/ui/Button.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/binding/TextArea.hpp>
 #include "KeybindEditPopup.hpp"
 
@@ -12,12 +13,12 @@ class SettingNodeV3::Impl final {
 public:
     std::shared_ptr<SettingV3> setting;
     CCLayerColor* bg;
-    CCLabelBMFont* nameLabel;
+    Label* nameLabel;
     CCMenu* nameMenu;
     CCMenu* buttonMenu;
     CCMenuItemSpriteExtra* resetButton;
     CCMenuItemSpriteExtra* descButton;
-    CCLabelBMFont* statusLabel;
+    Label* statusLabel;
     ccColor4B bgColor = ccc4(0, 0, 0, 0);
     bool committed = false;
     // This is because you can create `TitleSettingNodeV3`s without having an
@@ -43,11 +44,11 @@ bool SettingNodeV3::init(std::shared_ptr<SettingV3> setting, float width) {
     m_impl->nameMenu = CCMenu::create();
     m_impl->nameMenu->setContentWidth(width / 2 + 25);
 
-    m_impl->nameLabel = CCLabelBMFont::create(setting ? setting->getDisplayName().c_str() : "", "bigFont.fnt");
+    m_impl->nameLabel = Label::create(setting ? setting->getDisplayName() : "", "bigFont.fnt");
     m_impl->nameLabel->setLayoutOptions(AxisLayoutOptions::create()->setScaleLimits(.1f, .4f)->setScalePriority(1));
     m_impl->nameMenu->addChild(m_impl->nameLabel);
 
-    m_impl->statusLabel = CCLabelBMFont::create("", "bigFont.fnt");
+    m_impl->statusLabel = Label::create("", "bigFont.fnt");
     m_impl->statusLabel->setScale(.25f);
     this->addChildAtPosition(m_impl->statusLabel, Anchor::Left, ccp(10, -10), ccp(0, .5f));
 
@@ -95,13 +96,13 @@ void SettingNodeV3::updateState(CCNode* invoker) {
             m_impl->nameLabel->setColor(ccGRAY);
             m_impl->statusLabel->setVisible(true);
             m_impl->statusLabel->setColor("mod-list-errors-found"_cc3b);
-            m_impl->statusLabel->setString(desc->c_str());
+            m_impl->statusLabel->setText(std::move(*desc));
         }
     }
     if (m_impl->setting && m_impl->setting->requiresRestart() && m_impl->committed) {
         m_impl->statusLabel->setVisible(true);
         m_impl->statusLabel->setColor("mod-list-restart-required-label"_cc3b);
-        m_impl->statusLabel->setString("Restart Required");
+        m_impl->statusLabel->setText("Restart Required");
         m_impl->bg->setColor("mod-list-restart-required-label-bg"_cc3b);
         m_impl->bg->setOpacity(75);
     }
@@ -178,7 +179,7 @@ void SettingNodeV3::setContentSize(CCSize const& size) {
     SettingNodeSizeChangeEventV3(m_impl->setting->getModID(), m_impl->setting->getKey()).send(this);
 }
 
-CCLabelBMFont* SettingNodeV3::getNameLabel() const {
+Label* SettingNodeV3::getNameLabel() const {
     return m_impl->nameLabel;
 }
 
@@ -186,7 +187,7 @@ CCMenuItemSpriteExtra* SettingNodeV3::getDescriptionButton() const {
     return m_impl->descButton;
 }
 
-CCLabelBMFont* SettingNodeV3::getStatusLabel() const {
+Label* SettingNodeV3::getStatusLabel() const {
     return m_impl->statusLabel;
 }
 
@@ -238,7 +239,7 @@ bool TitleSettingNodeV3::init(std::shared_ptr<TitleSettingV3> setting, float wid
     this->getButtonMenu()->setContentWidth(20);
     this->getButtonMenu()->addChildAtPosition(m_collapseToggle, Anchor::Center);
 
-    this->getNameLabel()->setFntFile("goldFont.fnt");
+    this->getNameLabel()->setFont("goldFont.fnt");
     this->getNameMenu()->updateLayout();
     this->setContentHeight(20);
     this->updateState(nullptr);
@@ -289,7 +290,7 @@ TitleSettingNodeV3* TitleSettingNodeV3::create(std::shared_ptr<TitleSettingV3> s
 
 TitleSettingNodeV3* TitleSettingNodeV3::create(ZStringView title, std::optional<ZStringView> description, float width) {
     auto ret = TitleSettingNodeV3::create(nullptr, width);
-    ret->getNameLabel()->setString(title.c_str());
+    ret->getNameLabel()->setText(title);
     ret->overrideDescription(description);
     ret->updateState(nullptr);
     return ret;
@@ -419,7 +420,7 @@ void ButtonSettingNodeV3::updateState(CCNode* invoker) {
     enableButtons(loaded && getSetting()->shouldEnable());
 
     if (!loaded) {
-        this->getStatusLabel()->setString("Enable the mod to use these buttons");
+        this->getStatusLabel()->setText("Enable the mod to use these buttons");
         this->getStatusLabel()->setVisible(true);
     }
 
@@ -602,7 +603,8 @@ bool FileSettingNodeV3::init(std::shared_ptr<FileSettingV3> setting, float width
     m_fileIcon = CCSprite::create();
     this->getButtonMenu()->addChildAtPosition(m_fileIcon, Anchor::Left, ccp(5, 0));
 
-    m_nameLabel = CCLabelBMFont::create("", "bigFont.fnt");
+    m_nameLabel = Label::create("", "bigFont.fnt");
+    m_nameLabel->setLimitLabelWidth(75, .35f, .1f);
     this->getButtonMenu()->addChildAtPosition(m_nameLabel, Anchor::Left, ccp(13, 0), ccp(0, .5f));
 
     m_selectBtnSpr = CCSprite::createWithSpriteFrameName("GJ_plus2Btn_001.png");
@@ -636,20 +638,19 @@ void FileSettingNodeV3::updateState(CCNode* invoker) {
     limitNodeSize(m_fileIcon, ccp(10, 10), 1.f, .1f);
     if (this->getValue().empty() || isTextualDefaultValue) {
         if (isTextualDefaultValue) {
-            m_nameLabel->setString(utils::string::pathToString(this->getSetting()->getDefaultValue()).c_str());
+            m_nameLabel->setText(utils::string::pathToString(this->getSetting()->getDefaultValue()));
         }
         else {
-            m_nameLabel->setString(this->getSetting()->isFolder() ? "No Folder Selected" : "No File Selected");
+            m_nameLabel->setText(this->getSetting()->isFolder() ? "No Folder Selected" : "No File Selected");
         }
         m_nameLabel->setColor(ccGRAY);
         m_nameLabel->setOpacity(155);
     }
     else {
-        m_nameLabel->setString(utils::string::pathToString(this->getValue().filename()).c_str());
+        m_nameLabel->setText(utils::string::pathToString(this->getValue().filename()));
         m_nameLabel->setColor(ccWHITE);
         m_nameLabel->setOpacity(255);
     }
-    m_nameLabel->limitLabelWidth(75, .35f, .1f);
 
     auto enable = this->getSetting()->shouldEnable();
     m_selectBtnSpr->setOpacity(enable ? 255 : 155);
@@ -938,15 +939,15 @@ bool UnresolvedCustomSettingNodeV3::init(std::string_view key, Mod* mod, float w
 
     this->setContentHeight(30);
 
-    auto label = CCLabelBMFont::create(
+    auto label = Label::create(
         (mod && mod->isLoaded() ?
             fmt::format("Missing setting '{}'", key) :
             fmt::format("Enable the Mod to Edit '{}'", key)
-        ).c_str(),
+        ),
         "bigFont.fnt"
     );
     label->setColor(mod && mod->isLoaded() ? "mod-list-errors-found-2"_cc3b : "mod-list-gray"_cc3b);
-    label->limitLabelWidth(width - m_obContentSize.height, .3f, .1f);
+    label->setLimitLabelWidth(width - m_obContentSize.height, .3f, .1f);
     this->addChildAtPosition(label, Anchor::Left, ccp(m_obContentSize.height / 2, 0), ccp(0, .5f));
 
     return true;

--- a/loader/src/ui/mods/settings/SettingNodeV3.hpp
+++ b/loader/src/ui/mods/settings/SettingNodeV3.hpp
@@ -7,6 +7,7 @@
 #include <Geode/ui/ColorPickPopup.hpp>
 #include <Geode/ui/ScrollLayer.hpp>
 #include <Geode/ui/Button.hpp>
+#include <Geode/ui/Label.hpp>
 #include <ui/mods/GeodeStyle.hpp>
 
 using namespace geode::prelude;
@@ -306,7 +307,7 @@ public:
 class FileSettingNodeV3 : public SettingValueNodeV3<FileSettingV3> {
 protected:
     CCSprite* m_fileIcon;
-    CCLabelBMFont* m_nameLabel;
+    geode::Label* m_nameLabel;
     ListenerHandle m_pickHandle;
     async::TaskHolder<Result<std::optional<std::filesystem::path>>> m_pickListener;
     CCMenuItemSpriteExtra* m_selectBtn;

--- a/loader/src/ui/nodes/BasedButtonSprite.cpp
+++ b/loader/src/ui/nodes/BasedButtonSprite.cpp
@@ -1,4 +1,5 @@
 #include <Geode/ui/BasedButtonSprite.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/loader/Mod.hpp>
 #include <Geode/utils/cocos.hpp>
 
@@ -345,8 +346,8 @@ CCSize EditorButtonSprite::getMaxTopSize() const {
 
 TabButtonSprite* TabButtonSprite::create(char const* text, TabBaseColor color, TabBaseSize size) {
     auto ret = new TabButtonSprite();
-    auto label = CCLabelBMFont::create(text, "bigFont.fnt");
-    label->limitLabelWidth(75.f, .6f, .1f);
+    auto label = Label::create(text, "bigFont.fnt");
+    label->setLimitLabelWidth(75.f, .6f, .1f);
     if (ret->init(
         label, BaseType::Tab,
         static_cast<int>(size), static_cast<int>(color)

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -1,4 +1,5 @@
 #include <Geode/ui/Button.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/cocos.hpp>
 
 using namespace geode::prelude;
@@ -19,7 +20,7 @@ public:
     float m_touchMultiplier = 1.f;
 
     CCPoint m_offset = {0, -15};
-    
+
     float m_selectedDuration = 0.3f;
     float m_unselectedDuration = 0.4f;
 
@@ -143,7 +144,7 @@ bool Button::initWithSpriteFrameName(ZStringView frameName, ButtonCallback activ
 bool Button::initWithLabel(ZStringView text, ZStringView font, ButtonCallback activateCallback) {
     if (!Button::init(std::move(activateCallback))) return false;
 
-    m_impl->m_displayNode = CCLabelBMFont::create(text.c_str(), font.c_str());
+    m_impl->m_displayNode = Label::create(text, font);
     if (!m_impl->m_displayNode) return false;
 
     setContentSize(m_impl->m_displayNode->getScaledContentSize());
@@ -187,7 +188,7 @@ CCActionInterval* Button::clickActionForType() {
     }
 
     return nullptr;
-}   
+}
 
 CCActionInterval* Button::releaseActionForType() {
     switch (m_impl->m_animationType) {
@@ -206,7 +207,7 @@ CCActionInterval* Button::releaseActionForType() {
             return CCEaseInOut::create(moveTo, 2.f);
         }
     }
-    
+
     return nullptr;
 }
 
@@ -297,7 +298,7 @@ void Button::selected() {
 
 void Button::unselected() {
     if (!m_impl->m_selected) return;
-    
+
     stopAction(m_impl->m_activeClickAction);
     stopAction(m_impl->m_activeReleaseAction);
 

--- a/loader/src/ui/nodes/ColorPickPopup.cpp
+++ b/loader/src/ui/nodes/ColorPickPopup.cpp
@@ -4,6 +4,7 @@
 #include <Geode/binding/SliderThumb.hpp>
 #include <Geode/ui/ColorPickPopup.hpp>
 #include <Geode/ui/NineSlice.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/function.hpp>
 #include <charconv>
@@ -168,7 +169,7 @@ bool ColorPickPopup::init(ccColor4B const& color, bool isRGBA) {
     rColumn->setID("r-column");
     rgbRow->addChild(rColumn);
 
-    auto rText = CCLabelBMFont::create("R", "goldFont.fnt");
+    auto rText = Label::create("R", "goldFont.fnt");
     rText->setScale(.55f);
     rText->setID("r-text");
     rColumn->addChild(rText);
@@ -197,7 +198,7 @@ bool ColorPickPopup::init(ccColor4B const& color, bool isRGBA) {
     gColumn->setID("g-column");
     rgbRow->addChild(gColumn);
 
-    auto gText = CCLabelBMFont::create("G", "goldFont.fnt");
+    auto gText = Label::create("G", "goldFont.fnt");
     gText->setScale(.55f);
     gText->setID("g-text");
     gColumn->addChild(gText);
@@ -226,7 +227,7 @@ bool ColorPickPopup::init(ccColor4B const& color, bool isRGBA) {
     bColumn->setID("b-column");
     rgbRow->addChild(bColumn);
 
-    auto bText = CCLabelBMFont::create("B", "goldFont.fnt");
+    auto bText = Label::create("B", "goldFont.fnt");
     bText->setScale(.55f);
     bText->setID("b-text");
     bColumn->addChild(bText);
@@ -255,7 +256,7 @@ bool ColorPickPopup::init(ccColor4B const& color, bool isRGBA) {
     hexColumn->setID("hex-column");
     inputColumn->addChild(hexColumn);
 
-    auto hexText = CCLabelBMFont::create("Hex", "goldFont.fnt");
+    auto hexText = Label::create("Hex", "goldFont.fnt");
     hexText->setScale(.55f);
     hexText->setID("hex-text");
     hexColumn->addChild(hexText);
@@ -298,7 +299,7 @@ bool ColorPickPopup::init(ccColor4B const& color, bool isRGBA) {
         opacitySection->addChild(sliderColumn);
 
 
-        auto opacityText = CCLabelBMFont::create("Opacity", "goldFont.fnt");
+        auto opacityText = Label::create("Opacity", "goldFont.fnt");
         opacityText->setScale(.55f);
         opacityText->setID("opacity-text");
         sliderColumn->addChild(opacityText);

--- a/loader/src/ui/nodes/IconButtonSprite.cpp
+++ b/loader/src/ui/nodes/IconButtonSprite.cpp
@@ -1,4 +1,5 @@
 #include <Geode/ui/IconButtonSprite.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/cocos.hpp>
 #include <cocos-ext.h>
 
@@ -7,7 +8,7 @@ using namespace geode::prelude;
 class IconButtonSprite::Impl final {
 public:
     NineSlice* bg = nullptr;
-    cocos2d::CCLabelBMFont* label = nullptr;
+    geode::Label* label = nullptr;
     cocos2d::CCNode* icon = nullptr;
 };
 
@@ -28,8 +29,9 @@ bool IconButtonSprite::init(
     }
     this->addChild(m_impl->bg);
 
-    m_impl->label = CCLabelBMFont::create(text, font);
+    m_impl->label = Label::create(text, font);
     m_impl->label->setZOrder(1);
+    m_impl->label->setLimitLabelWidth(100, .6f, .1f);
     this->addChildAtPosition(m_impl->label, Anchor::Center);
 
     if (icon) {
@@ -50,7 +52,6 @@ void IconButtonSprite::updateLayout() {
 
     CCSize size = ccp(PADDING * 2, 35);
     if (hasText) {
-        m_impl->label->limitLabelWidth(100, .6f, .1f);
         size.width += m_impl->label->getScaledContentWidth();
         if (m_impl->icon) {
             size.width += PADDING;
@@ -165,7 +166,7 @@ NineSlice* IconButtonSprite::getBg() {
     return m_impl->bg;
 }
 
-cocos2d::CCLabelBMFont* IconButtonSprite::getLabel() {
+geode::Label* IconButtonSprite::getLabel() {
     return m_impl->label;
 }
 

--- a/loader/src/ui/nodes/MDPopup.cpp
+++ b/loader/src/ui/nodes/MDPopup.cpp
@@ -38,7 +38,7 @@ bool MDPopup::init(
     m_mainLayer->addChildAtPosition(content, Anchor::Center, ccp(0, 0));
 
     this->setTitle(title, "goldFont.fnt", .9f, 28.f);
-    m_title->limitLabelWidth(contentSize.width - 4.f, .9f, .1f);
+    m_title->setLimitLabelWidth(contentSize.width - 4.f, .9f, .1f);
 
     auto btnSpr = ButtonSprite::create(btn1Text.c_str());
 

--- a/loader/src/ui/nodes/Notification.cpp
+++ b/loader/src/ui/nodes/Notification.cpp
@@ -1,4 +1,5 @@
 #include <Geode/loader/Mod.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/LoadingSpinner.hpp>
 #include <Geode/ui/OverlayManager.hpp>
 #include <Geode/ui/Notification.hpp>
@@ -13,7 +14,7 @@ static std::deque<Ref<Notification>> s_queue;
 class Notification::Impl final {
 public:
     NineSlice* bg;
-    CCLabelBMFont* label;
+    Label* label;
     CCNodeRGBA* content;
     CCNode* icon = nullptr;
     float time;
@@ -49,7 +50,7 @@ bool Notification::init(ZStringView text, CCNode* icon, float time) {
         m_impl->content->addChild(icon);
     }
 
-    m_impl->label = CCLabelBMFont::create(text.c_str(), "bigFont.fnt");
+    m_impl->label = Label::create(text, "bigFont.fnt");
     m_impl->label->setScale(.6f);
     m_impl->content->addChild(m_impl->label);
 
@@ -128,7 +129,7 @@ Notification* Notification::create(ZStringView text, CCNode* icon, float time) {
 }
 
 void Notification::setString(ZStringView text) {
-    m_impl->label->setString(text.c_str());
+    m_impl->label->setText(text);
     this->updateLayout();
 }
 
@@ -167,7 +168,7 @@ NineSlice* Notification::getBG() {
     return m_impl->bg;
 }
 
-CCLabelBMFont* Notification::getLabel() {
+Label* Notification::getLabel() {
     return m_impl->label;
 }
 

--- a/loader/src/ui/nodes/Popup.cpp
+++ b/loader/src/ui/nodes/Popup.cpp
@@ -1,5 +1,6 @@
 #include <Geode/Enums.hpp>
 #include <Geode/binding/GameManager.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/Popup.hpp>
 #include <Geode/binding/FLAlertLayer.hpp>
 #include <Geode/binding/FLAlertLayerProtocol.hpp>
@@ -90,7 +91,7 @@ bool Popup::init(
     if (!this->initWithColor({ 0, 0, 0, 105 })) return false;
 
     m_noElasticity = GameManager::get()->getGameVariable(GameVar::FastMenu);
-    
+
     auto winSize = CCDirector::get()->getWinSize();
 
     m_mainLayer = CCLayer::create();
@@ -154,13 +155,13 @@ void Popup::setTitle(
     float offset
 ) {
     if (!m_title) {
-        m_title = CCLabelBMFont::create("", font);
+        m_title = Label::create("", font);
         m_title->setZOrder(2);
         m_mainLayer->addChildAtPosition(m_title, Anchor::Top, {0, -offset});
     }
-    
-    m_title->setString(title.c_str());
-    m_title->limitLabelWidth(m_size.width - 20.f, scale, .1f);
+
+    m_title->setText(title);
+    m_title->setLimitLabelWidth(m_size.width - 20.f, scale, .1f);
 }
 
 void Popup::setCloseButtonSpr(CCSprite* spr, float scale) {

--- a/loader/src/ui/nodes/ProgressBar.cpp
+++ b/loader/src/ui/nodes/ProgressBar.cpp
@@ -1,4 +1,5 @@
 #include <Geode/ui/ProgressBar.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/cocos.hpp>
 
 using namespace geode::prelude;
@@ -10,7 +11,7 @@ public:
     // Progress bar fill
     CCSprite* progressBarFill = nullptr;
     // The text label displaying the percentage
-    Ref<CCLabelBMFont> progressPercentLabel = nullptr;
+    Ref<Label> progressPercentLabel = nullptr;
 
     // Current progress bar fill percentage ranging from 0 to 100
     float progress = 0.0f;
@@ -52,12 +53,12 @@ public:
         progressBarFillMaxWidth = progressBar->getScaledContentWidth() - 4.0f;
         progressBarFillMaxHeight = progressBarFill->getScaledContentHeight() - 0.5f;
 
-        progressPercentLabel = CCLabelBMFont::create("0%", "bigFont.fnt");
+        progressPercentLabel = Label::create("0%", "bigFont.fnt");
         progressPercentLabel->setID("progress-percent-label");
         progressPercentLabel->setScale(0.5f);
         progressPercentLabel->setAnchorPoint({ 0, 0.5 });
         progressPercentLabel->setPosition({ progressBar->getScaledContentWidth() + 2.5f, progressBar->getScaledContentHeight() / 2.0f });
-        progressPercentLabel->setAlignment(CCTextAlignment::kCCTextAlignmentLeft);
+        progressPercentLabel->setAlignment(Label::Alignment::Left);
         progressPercentLabel->setVisible(showProgressPercentLabel);
         progressPercentLabel->setZOrder(1);
     };
@@ -84,12 +85,12 @@ public:
         progressBarFillMaxWidth = progressBar->getScaledContentWidth();
         progressBarFillMaxHeight = 20.0f;
 
-        progressPercentLabel = CCLabelBMFont::create("0%", "bigFont.fnt");
+        progressPercentLabel = Label::create("0%", "bigFont.fnt");
         progressPercentLabel->setID("progress-percent-label");
         progressPercentLabel->setScale(0.5f);
         progressPercentLabel->setAnchorPoint({ 0.5, 0.5 });
         progressPercentLabel->setPosition({ progressBar->getScaledContentWidth() / 2.0f, progressBar->getScaledContentHeight() / 2.0f });
-        progressPercentLabel->setAlignment(CCTextAlignment::kCCTextAlignmentCenter);
+        progressPercentLabel->setAlignment(Label::Alignment::Center);
         progressPercentLabel->setVisible(showProgressPercentLabel);
         progressPercentLabel->setZOrder(1);
     };
@@ -160,7 +161,7 @@ void ProgressBar::updateProgress(float value) {
 
     if (m_impl->progressPercentLabel) {
         auto percentString = fmt::format("{}%", geode::utils::numToString(m_impl->progress, m_impl->precision));
-        m_impl->progressPercentLabel->setCString(percentString.c_str());
+        m_impl->progressPercentLabel->setText(std::move(percentString));
     };
 };
 
@@ -173,7 +174,7 @@ float ProgressBar::getProgress() const noexcept {
     return m_impl->progress;
 };
 
-CCLabelBMFont* ProgressBar::getProgressLabel() const noexcept {
+Label* ProgressBar::getProgressLabel() const noexcept {
     return m_impl->progressPercentLabel;
 };
 

--- a/loader/src/ui/nodes/SliderNode.cpp
+++ b/loader/src/ui/nodes/SliderNode.cpp
@@ -1,4 +1,5 @@
 #include <Geode/ui/SliderNode.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/Geode.hpp>
 
 using namespace geode::prelude;
@@ -23,15 +24,15 @@ public:
     CCSprite* m_thumbSelected;
     CCSprite* m_bar;
     geode::NineSlice* m_groove;
-    
+
     SliderCallback m_slideCallback;
     SliderCallback m_clickCallback;
     SliderCallback m_releaseCallback;
-    
+
     geode::TextInput* m_linkedTextInput;
     unsigned int m_textInputPrecision;
 
-    CCLabelBMFont* m_linkedLabel;
+    Label* m_linkedLabel;
     unsigned int m_labelPrecision;
 
     int m_touchPriority = kCCMenuHandlerPriority;
@@ -82,12 +83,12 @@ bool SliderNode::initCustom(CCSprite* thumb, CCSprite* thumbSelected, NineSlice*
 
     m_impl->m_thumb->addChild(m_impl->m_thumbRegular);
     m_impl->m_thumb->addChild(m_impl->m_thumbSelected);
-    
+
     addChild(m_impl->m_thumb);
 
     m_impl->m_groove = groove;
     m_impl->m_bar->setZOrder(-1);
-    
+
     auto repeat = ccTexParams{GL_LINEAR, GL_LINEAR, GL_REPEAT, GL_REPEAT};
     m_impl->m_bar->getTexture()->setTexParameters(&repeat);
     m_impl->m_bar->setAnchorPoint({0.f, 0.5f});
@@ -116,7 +117,7 @@ bool SliderNode::initCustom(CCSprite* thumb, CCSprite* thumbSelected, NineSlice*
 bool SliderNode::initStandard(SliderCallback callback, bool alt) {
     auto thumb = CCSprite::create("sliderthumb.png"_spr);
     auto thumbSel = CCSprite::create("sliderthumbsel.png"_spr);
-    
+
     if (alt) {
         auto groove = geode::NineSlice::create("slider-groove-2.png"_spr);
         return initCustom(thumb, thumbSel, groove, "sliderBar2.png", std::move(callback), {2.f, 2.f});
@@ -130,7 +131,7 @@ bool SliderNode::initStandard(SliderCallback callback, bool alt) {
 void SliderNode::updateSize() {
     m_impl->m_groove->setContentSize(getContentSize());
     m_impl->m_groove->setPosition(getContentSize() / 2.f);
-    
+
     m_impl->m_bar->setContentWidth(getContentWidth() - m_impl->m_barOffset.width * 2);
 
     float usableHeight = getContentHeight() - m_impl->m_barOffset.height * 2.f;
@@ -226,10 +227,10 @@ void SliderNode::updateLinkedTextInput() {
 void SliderNode::updateLinkedLabel() {
     if (m_impl->m_linkedLabel) {
         if (m_impl->m_labelPrecision != 0) {
-            m_impl->m_linkedLabel->setString(numToString(getValue(), m_impl->m_labelPrecision).c_str());
+            m_impl->m_linkedLabel->setText(numToString(getValue(), m_impl->m_labelPrecision));
         }
         else {
-            m_impl->m_linkedLabel->setString(numToString<int>(std::round(getValue())).c_str());
+            m_impl->m_linkedLabel->setText(numToString<int>(std::round(getValue())));
         }
     }
 }
@@ -275,7 +276,7 @@ geode::TextInput* SliderNode::getLinkedTextInput() {
     return m_impl->m_linkedTextInput;
 }
 
-void SliderNode::linkLabel(CCLabelBMFont* label, unsigned int precision) {
+void SliderNode::linkLabel(Label* label, unsigned int precision) {
     m_impl->m_linkedLabel = label;
     m_impl->m_labelPrecision = precision;
     updateLinkedLabel();
@@ -294,7 +295,7 @@ unsigned int SliderNode::getLabelPrecision() {
     return m_impl->m_labelPrecision;
 }
 
-CCLabelBMFont* SliderNode::getLinkedLabel() {
+Label* SliderNode::getLinkedLabel() {
     return m_impl->m_linkedLabel;
 }
 

--- a/loader/src/ui/nodes/TextArea.cpp
+++ b/loader/src/ui/nodes/TextArea.cpp
@@ -1,4 +1,5 @@
 #include <Geode/ui/TextArea.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/utils/cocos.hpp>
 #include <Geode/utils/web.hpp>
 #include <regex>
@@ -11,7 +12,7 @@ public:
     cocos2d::CCMenu* m_container = nullptr;
     std::string m_font;
     std::string m_text;
-    std::vector<cocos2d::CCLabelBMFont*> m_lines;
+    std::vector<geode::Label*> m_lines;
     cocos2d::ccColor4B m_color = { 0xFF, 0xFF, 0xFF, 0xFF };
     cocos2d::CCTextAlignment m_alignment = cocos2d::kCCTextAlignmentLeft;
     geode::WrappingMode m_wrappingMode = geode::WrappingMode::WORD_WRAP;
@@ -24,11 +25,11 @@ public:
 
     SimpleTextAreaImpl(geode::SimpleTextArea* self) : m_self(self) {}
 
-    cocos2d::CCLabelBMFont* createLabel(char const* text, float top);
+    geode::Label* createLabel(std::string text, float top);
 
-    float calculateOffset(cocos2d::CCLabelBMFont* label);
+    float calculateOffset(geode::Label* label);
 
-    virtual void charIteration(geode::FunctionRef<cocos2d::CCLabelBMFont*(cocos2d::CCLabelBMFont* line, char c, float top)> overflowHandling);
+    virtual void charIteration(geode::FunctionRef<geode::Label*(geode::Label* line, char c, float top)> overflowHandling);
 
     void updateLinesNoWrap();
 
@@ -41,16 +42,16 @@ public:
     virtual void setTextImpl(std::string text);
 };
 
-cocos2d::CCLabelBMFont* geode::SimpleTextAreaImpl::createLabel(char const* text, float top) {
+geode::Label* geode::SimpleTextAreaImpl::createLabel(std::string text, float top) {
     if (m_maxLines && m_lines.size() >= m_maxLines) {
-        cocos2d::CCLabelBMFont* last = m_lines.at(m_maxLines - 1);
+        geode::Label* last = m_lines.at(m_maxLines - 1);
         std::string_view textv = last->getString();
 
-        last->setString(fmt::format("{}...", textv.substr(0, textv.size() - 3)).c_str());
+        last->setText(fmt::format("{}...", textv.substr(0, textv.size() - 3)));
 
         return nullptr;
     } else {
-        cocos2d::CCLabelBMFont* label = cocos2d::CCLabelBMFont::create(text, m_font.c_str());
+        geode::Label* label = geode::Label::create(std::move(text), m_font.c_str());
 
         label->setScale(m_scale);
         label->setPosition({ 0, top });
@@ -61,14 +62,14 @@ cocos2d::CCLabelBMFont* geode::SimpleTextAreaImpl::createLabel(char const* text,
     }
 }
 
-float geode::SimpleTextAreaImpl::calculateOffset(cocos2d::CCLabelBMFont* label) {
+float geode::SimpleTextAreaImpl::calculateOffset(geode::Label* label) {
     return m_linePadding + label->getContentSize().height * m_scale;
 }
 
-void geode::SimpleTextAreaImpl::charIteration(geode::FunctionRef<cocos2d::CCLabelBMFont*(cocos2d::CCLabelBMFont* line, char c, float top)> overflowHandling) {
+void geode::SimpleTextAreaImpl::charIteration(geode::FunctionRef<geode::Label*(geode::Label* line, char c, float top)> overflowHandling) {
     float top = 0;
     m_lines.clear();
-    cocos2d::CCLabelBMFont* line = createLabel("", top);
+    geode::Label* line = createLabel("", top);
     m_lines = { line };
 
     for (const char c : m_text) {
@@ -89,7 +90,7 @@ void geode::SimpleTextAreaImpl::charIteration(geode::FunctionRef<cocos2d::CCLabe
                 m_lines.push_back(line);
             }
         } else {
-            line->setString((std::string(line->getString()) + c).c_str());
+            line->setText((std::string(line->getString()) + c));
         }
     }
 }
@@ -101,7 +102,7 @@ void geode::SimpleTextAreaImpl::updateLinesNoWrap() {
     m_lines.clear();
 
     while (std::getline(stream, part)) {
-        cocos2d::CCLabelBMFont* line = createLabel(part.c_str(), top);
+        geode::Label* line = createLabel(std::move(part), top);
 
         if (line == nullptr) {
             break;
@@ -114,37 +115,37 @@ void geode::SimpleTextAreaImpl::updateLinesNoWrap() {
 }
 
 void geode::SimpleTextAreaImpl::updateLinesWordWrap(bool spaceWrap) {
-    charIteration([this, spaceWrap](cocos2d::CCLabelBMFont* line, char c, float top) {
+    charIteration([this, spaceWrap](geode::Label* line, char c, float top) {
         const std::string_view delimiters(spaceWrap ? " " : " `~!@#$%^&*()-_=+[{}];:'\",<.>/?\\|");
 
         if (delimiters.find(c) == std::string_view::npos) {
             const std::string& text = line->getString();
             const size_t position = text.find_last_of(delimiters) + 1;
-            cocos2d::CCLabelBMFont* newLine = createLabel((text.substr(position) + c).c_str(), top);
+            geode::Label* newLine = createLabel(text.substr(position) + c, top);
 
             if (newLine != nullptr) {
-                line->setString(text.substr(0, position).c_str());
+                line->setText(text.substr(0, position));
             }
 
             return newLine;
         } else {
-            return createLabel(std::string(c, c != ' ').c_str(), top);
+            return createLabel(std::string(c != ' ', c), top);
         }
     });
 }
 
 void geode::SimpleTextAreaImpl::updateLinesCutoffWrap() {
-    charIteration([this](cocos2d::CCLabelBMFont* line, char c, float top) {
+    charIteration([this](geode::Label* line, char c, float top) {
         const std::string& text = line->getString();
         const char back = text.back();
         const bool lastIsSpace = back == ' ';
-        cocos2d::CCLabelBMFont* newLine = createLabel(std::string(!lastIsSpace, back).append(std::string(c != ' ', c)).c_str(), top);
+        geode::Label* newLine = createLabel(std::string(!lastIsSpace, back).append(std::string(c != ' ', c)), top);
 
         if (newLine == nullptr && !lastIsSpace) {
             if (text[text.size() - 2] == ' ') {
-                line->setString(text.substr(0, text.size() - 1).c_str());
+                line->setText(text.substr(0, text.size() - 1));
             } else {
-                line->setString((text.substr(0, text.size() - 1) + '-').c_str());
+                line->setText(text.substr(0, text.size() - 1) + '-');
             }
         }
 
@@ -184,7 +185,7 @@ void geode::SimpleTextAreaImpl::updateContainer() {
     m_container->setContentSize(m_self->getContentSize());
     m_container->removeAllChildren();
 
-    for (cocos2d::CCLabelBMFont* line : m_lines) {
+    for (geode::Label* line : m_lines) {
         const float y = height + line->getPositionY();
 
         switch (m_alignment) {
@@ -341,7 +342,7 @@ float geode::SimpleTextArea::getLinePadding() {
     return m_impl->m_linePadding;
 }
 
-std::vector<cocos2d::CCLabelBMFont*> geode::SimpleTextArea::getLines() {
+std::vector<geode::Label*> geode::SimpleTextArea::getLines() {
     return m_impl->m_lines;
 }
 
@@ -373,7 +374,7 @@ public:
 
     std::map<CCFontSprite*, ccColor3B> m_ogColorForLink{};
 
-    void charIteration(geode::FunctionRef<cocos2d::CCLabelBMFont*(cocos2d::CCLabelBMFont* line, char c, float top)> overflowHandling) override;
+    void charIteration(geode::FunctionRef<geode::Label*(geode::Label* line, char c, float top)> overflowHandling) override;
     void formatRichText();
 
     void processLinkClick(
@@ -520,10 +521,10 @@ std::string RichTextArea::getRawText(){
     return castedImpl()->m_rawText;
 }
 
-void RichTextArea::RichImpl::charIteration(geode::FunctionRef<cocos2d::CCLabelBMFont*(cocos2d::CCLabelBMFont* line, char c, float top)> overflowHandling) {
+void RichTextArea::RichImpl::charIteration(geode::FunctionRef<geode::Label*(geode::Label* line, char c, float top)> overflowHandling) {
     float top = 0;
     m_lines.clear();
-    CCLabelBMFont* line = this->createLabel("", top);
+    geode::Label* line = this->createLabel("", top);
     m_lines = { line };
 
     std::map<std::string, std::shared_ptr<RichTextKeyInstanceBase>> appliedRichTextInstances{};
@@ -571,7 +572,7 @@ void RichTextArea::RichImpl::charIteration(geode::FunctionRef<cocos2d::CCLabelBM
                 m_lines.push_back(line);
             }
         } else {
-            line->setString((std::string(line->getString()) + c).c_str());
+            line->setText((std::string(line->getString()) + c));
         }
 
         if (line->getChildren()->lastObject() != nullptr){

--- a/loader/src/ui/nodes/TextInput.cpp
+++ b/loader/src/ui/nodes/TextInput.cpp
@@ -1,6 +1,7 @@
 #include <Geode/binding/CCTextInputNode.hpp>
 #include <Geode/binding/TextInputDelegate.hpp>
 #include <Geode/modify/CCTextInputNode.hpp>
+#include <Geode/ui/Label.hpp>
 #include <Geode/ui/TextInput.hpp>
 #include <Geode/utils/cocos.hpp>
 
@@ -72,7 +73,7 @@ public:
     NineSlice* bgSprite = nullptr;
     CCTextInputNode* input = nullptr;
     geode::Function<void(std::string const&)> onInput = nullptr;
-    cocos2d::CCLabelBMFont* label = nullptr;
+    geode::Label* label = nullptr;
     bool callbackEnabled = true;
 };
 
@@ -130,13 +131,13 @@ void TextInput::setPlaceholder(gd::string placeholder) {
 void TextInput::setLabel(ZStringView label) {
     if (label.size()) {
         if (m_impl->label) {
-            m_impl->label->setString(label.c_str());
+            m_impl->label->setText(label);
         }
         else {
-            m_impl->label = CCLabelBMFont::create(label.c_str(), "goldFont.fnt");
+            m_impl->label = Label::create(label, "goldFont.fnt");
+            m_impl->label->setLimitLabelWidth(m_impl->bgSprite->getScaledContentWidth() - 6, .4f, .1f);
             this->addChildAtPosition(m_impl->label, Anchor::TopLeft, ccp(3, 2), ccp(0, 0));
         }
-        m_impl->label->limitLabelWidth(m_impl->bgSprite->getScaledContentWidth() - 6, .4f, .1f);
     }
     else {
         if (m_impl->label) {
@@ -165,6 +166,9 @@ void TextInput::setWidth(float width) {
     m_impl->bgSprite->setContentWidth(width * 2);
     m_impl->input->setPositionX(width / 2.f);
     m_impl->bgSprite->setPositionX(width / 2.f);
+    if (m_impl->label) {
+        m_impl->label->setLimitLabelWidth(m_impl->bgSprite->getScaledContentWidth() - 6, .4f, .1f);
+    }
 }
 void TextInput::setDelegate(TextInputDelegate* delegate, std::optional<int> tag) {
     m_impl->input->m_delegate = delegate;

--- a/loader/src/utils/Keyboard.cpp
+++ b/loader/src/utils/Keyboard.cpp
@@ -1,5 +1,6 @@
 #include <Geode/loader/Mod.hpp>
 #include <Geode/utils/StringMap.hpp>
+#include <Geode/ui/Label.hpp>
 
 using namespace geode::prelude;
 
@@ -330,7 +331,7 @@ std::string Keybind::toString() const {
 cocos2d::CCNode* Keybind::createNode() const {
     // If this is not a controller bind, just return a label with the key name
     if ((key < CONTROLLER_A || key > CONTROLLER2_RTHUMBSTICK_RIGHT) && (key < CONTROLLER_L3 || key > CONTROLLER2_R3)) {
-        return CCLabelBMFont::create(this->toString().c_str(), "bigFont.fnt");
+        return Label::create(this->toString(), "bigFont.fnt");
     }
 
     auto isController2 = (key & 0x1) == 0x0;
@@ -367,7 +368,7 @@ cocos2d::CCNode* Keybind::createNode() const {
         default: sprite = nullptr;
     }
     if (!sprite) {
-        return CCLabelBMFont::create("Unknown", "bigFont.fnt");
+        return Label::create("Unknown", "bigFont.fnt");
     }
 
     auto spr = CCSprite::createWithSpriteFrameName(sprite);
@@ -413,7 +414,7 @@ cocos2d::CCNode* Keybind::createNode() const {
     }
 
     if (isController2) {
-        auto indicator = CCLabelBMFont::create("(2)", "bigFont.fnt");
+        auto indicator = Label::create("(2)", "bigFont.fnt");
         indicator->setPosition(ccp(31.f, 31.f));
         indicator->setScale(0.4f);
         indicator->setOpacity(127);


### PR DESCRIPTION
Tried to not just find & replace, I attempted to optimize create() and setString() usage wherever I could.

This obviously will lead to some API breaks, so I'm basing it on v6.

I think this is the full list:

- `SettingNodeV3::getNameLabel()`: changed return type
- `SettingNodeV3::getStatusLabel()`: changed return type
- `IconButtonSprite::getLabel()`: changed return type
- `Notification::getLabel()`: changed return type
- `Popup::m_title`: is now `geode::Label`
- `ProgressBar::getProgressLabel()`: changed return type
- `SelectList::m_label`: is now `geode::Label`
- `SliderNode::linkLabel()`: requires `geode::Label` for 1st param
- `SliderNode::getLinkedLabel()`: changed return type
- `SimpleTextArea::getLines()`: returns `vector<Label*>`

The majority of those should not be issues for most devs, besides Popup, SliderNode and SelectList.